### PR TITLE
Revise Doc

### DIFF
--- a/flowvision/data/mixup.py
+++ b/flowvision/data/mixup.py
@@ -42,7 +42,7 @@ def rand_bbox(img_shape, lam, margin=0.0, count=None):
         img_shape (tuple): Image shape as tuple
         lam (float): Cutmix lambda value
         margin (float): Percentage of bbox dimension to enforce as margin (reduce amount of box outside image)
-        count (int): Number of bbox to generate.
+        count (int): Number of bbox to generate
     """
     ratio = np.sqrt(1 - lam)
     img_h, img_w = img_shape[-2:]
@@ -65,7 +65,7 @@ def rand_bbox_minmax(img_shape, minmax, count=None):
     Args:
         img_shape (tuple): Image shape as tuple
         minmax (tuple or list): Min and max bbox ratios (as percent of image size)
-        count (int): Number of bbox to generate.
+        count (int): Number of bbox to generate
     """
     assert len(minmax) == 2
     img_h, img_w = img_shape[-2:]
@@ -101,15 +101,15 @@ def cutmix_bbox_and_lam(
 class Mixup:
     """ Mixup/Cutmix that applies different params to each element or whole batch
     Args:
-        mixup_alpha (float): mixup alpha value, mixup is active if > 0.
-        cutmix_alpha (float): cutmix alpha value, cutmix is active if > 0.
-        cutmix_minmax (List[float]): cutmix min/max image ratio, cutmix is active and uses this vs alpha if not None.
-        prob (float): probability of applying mixup or cutmix per batch or element
-        switch_prob (float): probability of switching to cutmix instead of mixup when both are active
-        mode (str): how to apply mixup/cutmix params (per 'batch', 'pair' (pair of elements), 'elem' (element)
-        correct_lam (bool): apply lambda correction when cutmix bbox clipped by image borders
-        label_smoothing (float): apply label smoothing to the mixed target tensor
-        num_classes (int): number of classes for target.
+        mixup_alpha (float): Mixup alpha value, mixup is active if > 0.
+        cutmix_alpha (float): Cutmix alpha value, cutmix is active if > 0.
+        cutmix_minmax (List[float]): Cutmix min/max image ratio, cutmix is active and uses this vs alpha if not None.
+        prob (float): Probability of applying mixup or cutmix per batch or element
+        switch_prob (float): Probability of switching to cutmix instead of mixup when both are active
+        mode (str): How to apply mixup/cutmix params (per 'batch', 'pair' (pair of elements), 'elem' (element)
+        correct_lam (bool): Apply lambda correction when cutmix bbox clipped by image borders
+        label_smoothing (float): Apply label smoothing to the mixed target tensor
+        num_classes (int): Number of classes for target
     """
 
     def __init__(

--- a/flowvision/data/mixup.py
+++ b/flowvision/data/mixup.py
@@ -42,7 +42,7 @@ def rand_bbox(img_shape, lam, margin=0.0, count=None):
         img_shape (tuple): Image shape as tuple
         lam (float): Cutmix lambda value
         margin (float): Percentage of bbox dimension to enforce as margin (reduce amount of box outside image)
-        count (int): Number of bbox to generate
+        count (int): Number of bbox to generate.
     """
     ratio = np.sqrt(1 - lam)
     img_h, img_w = img_shape[-2:]
@@ -65,7 +65,7 @@ def rand_bbox_minmax(img_shape, minmax, count=None):
     Args:
         img_shape (tuple): Image shape as tuple
         minmax (tuple or list): Min and max bbox ratios (as percent of image size)
-        count (int): Number of bbox to generate
+        count (int): Number of bbox to generate.
     """
     assert len(minmax) == 2
     img_h, img_w = img_shape[-2:]
@@ -109,7 +109,7 @@ class Mixup:
         mode (str): how to apply mixup/cutmix params (per 'batch', 'pair' (pair of elements), 'elem' (element)
         correct_lam (bool): apply lambda correction when cutmix bbox clipped by image borders
         label_smoothing (float): apply label smoothing to the mixed target tensor
-        num_classes (int): number of classes for target
+        num_classes (int): number of classes for target.
     """
 
     def __init__(

--- a/flowvision/data/mixup.py
+++ b/flowvision/data/mixup.py
@@ -101,9 +101,9 @@ def cutmix_bbox_and_lam(
 class Mixup:
     """ Mixup/Cutmix that applies different params to each element or whole batch
     Args:
-        mixup_alpha (float): Mixup alpha value, mixup is active if > 0.
-        cutmix_alpha (float): Cutmix alpha value, cutmix is active if > 0.
-        cutmix_minmax (List[float]): Cutmix min/max image ratio, cutmix is active and uses this vs alpha if not None.
+        mixup_alpha (float): Mixup alpha value, mixup is active if > 0
+        cutmix_alpha (float): Cutmix alpha value, cutmix is active if > 0
+        cutmix_minmax (List[float]): Cutmix min/max image ratio, cutmix is active and uses this vs alpha if not None
         prob (float): Probability of applying mixup or cutmix per batch or element
         switch_prob (float): Probability of switching to cutmix instead of mixup when both are active
         mode (str): How to apply mixup/cutmix params (per 'batch', 'pair' (pair of elements), 'elem' (element)

--- a/flowvision/data/random_erasing.py
+++ b/flowvision/data/random_erasing.py
@@ -28,12 +28,12 @@ class RandomErasing:
          min_area: Minimum percentage of erased area wrt input image area
          max_area: Maximum percentage of erased area wrt input image area
          min_aspect: Minimum aspect ratio of erased area
-         mode: pixel color mode, one of 'const', 'rand', or 'pixel'
+         mode: Pixel color mode, one of 'const', 'rand', or 'pixel'
             'const' - erase block is constant color of 0 for all channels
             'rand'  - erase block is same per-channel random (normal) color
             'pixel' - erase block is per-pixel random (normal) color
-        max_count: maximum number of erasing blocks per image, area per box is scaled by count.
-            per-image count is randomly chosen between 1 and this value.
+        max_count: Maximum number of erasing blocks per image, area per box is scaled by count.
+            per-image count is randomly chosen between 1 and this value
     """
 
     def __init__(

--- a/flowvision/data/random_erasing.py
+++ b/flowvision/data/random_erasing.py
@@ -24,10 +24,10 @@ class RandomErasing:
         This variant of RandomErasing is intended to be applied to either a batch
         or single image tensor after it has been normalized by dataset mean and std.
     Args:
-         probability: Probability that the Random Erasing operation will be performed.
-         min_area: Minimum percentage of erased area wrt input image area.
-         max_area: Maximum percentage of erased area wrt input image area.
-         min_aspect: Minimum aspect ratio of erased area.
+         probability: Probability that the Random Erasing operation will be performed
+         min_area: Minimum percentage of erased area wrt input image area
+         max_area: Maximum percentage of erased area wrt input image area
+         min_aspect: Minimum aspect ratio of erased area
          mode: pixel color mode, one of 'const', 'rand', or 'pixel'
             'const' - erase block is constant color of 0 for all channels
             'rand'  - erase block is same per-channel random (normal) color

--- a/flowvision/models/_utils.py
+++ b/flowvision/models/_utils.py
@@ -22,7 +22,7 @@ class IntermediateLayerGetter(nn.ModuleDict):
         return_layers (Dict[name, new_name]): a dict containing the names
             of the modules for which the activations will be returned as
             the key of the dict, and the value of the dict is the name
-            of the returned activation (which the user can specify).
+            of the returned activation (which the user can specify)
     """
 
     __annotations__ = {

--- a/flowvision/models/alexnet.py
+++ b/flowvision/models/alexnet.py
@@ -1,5 +1,5 @@
 """
-Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/alexnet.py
+Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/alexnet.py.
 """
 from typing import Any
 

--- a/flowvision/models/alexnet.py
+++ b/flowvision/models/alexnet.py
@@ -66,7 +66,7 @@ def alexnet(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> A
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 

--- a/flowvision/models/alexnet.py
+++ b/flowvision/models/alexnet.py
@@ -62,11 +62,11 @@ def alexnet(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> A
 
     .. note::
         AlexNet model architecture from the `One weird trick... <https://arxiv.org/abs/1404.5997>`_ paper.
-        The required minimum input size of the model is 63x63.
+        The required minimum input size of this model is 63x63.
 
     Args:
-        pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``.
+        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``.
 
     For example:
 

--- a/flowvision/models/alexnet.py
+++ b/flowvision/models/alexnet.py
@@ -1,5 +1,5 @@
 """
-Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/alexnet.py.
+Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/alexnet.py
 """
 from typing import Any
 

--- a/flowvision/models/alexnet.py
+++ b/flowvision/models/alexnet.py
@@ -65,7 +65,7 @@ def alexnet(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> A
         The required minimum input size of this model is 63x63.
 
     Args:
-        pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``.
+        pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
         progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:

--- a/flowvision/models/alexnet.py
+++ b/flowvision/models/alexnet.py
@@ -66,7 +66,7 @@ def alexnet(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> A
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``.
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 

--- a/flowvision/models/conv_mixer.py
+++ b/flowvision/models/conv_mixer.py
@@ -1,5 +1,5 @@
 """
-Modified from https://github.com/tmp-iclr/convmixer/blob/main/convmixer.py.
+Modified from https://github.com/tmp-iclr/convmixer/blob/main/convmixer.py
 """
 import oneflow as flow
 import oneflow.nn as nn

--- a/flowvision/models/conv_mixer.py
+++ b/flowvision/models/conv_mixer.py
@@ -70,7 +70,7 @@ def convmixer_1536_20(pretrained: bool = False, progress: bool = True, **kwargs)
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -101,7 +101,7 @@ def convmixer_768_32_relu(pretrained: bool = False, progress: bool = True, **kwa
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -134,7 +134,7 @@ def convmixer_1024_20(pretrained: bool = False, progress: bool = True, **kwargs)
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 

--- a/flowvision/models/conv_mixer.py
+++ b/flowvision/models/conv_mixer.py
@@ -70,7 +70,7 @@ def convmixer_1536_20(pretrained: bool = False, progress: bool = True, **kwargs)
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -101,7 +101,7 @@ def convmixer_768_32_relu(pretrained: bool = False, progress: bool = True, **kwa
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -134,7 +134,7 @@ def convmixer_1024_20(pretrained: bool = False, progress: bool = True, **kwargs)
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 

--- a/flowvision/models/conv_mixer.py
+++ b/flowvision/models/conv_mixer.py
@@ -1,5 +1,5 @@
 """
-Modified from https://github.com/tmp-iclr/convmixer/blob/main/convmixer.py
+Modified from https://github.com/tmp-iclr/convmixer/blob/main/convmixer.py.
 """
 import oneflow as flow
 import oneflow.nn as nn

--- a/flowvision/models/conv_mixer.py
+++ b/flowvision/models/conv_mixer.py
@@ -70,7 +70,7 @@ def convmixer_1536_20(pretrained: bool = False, progress: bool = True, **kwargs)
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -101,7 +101,7 @@ def convmixer_768_32_relu(pretrained: bool = False, progress: bool = True, **kwa
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -134,7 +134,7 @@ def convmixer_1024_20(pretrained: bool = False, progress: bool = True, **kwargs)
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 

--- a/flowvision/models/crossformer.py
+++ b/flowvision/models/crossformer.py
@@ -1,5 +1,5 @@
 """
-Modified from https://github.com/cheerss/CrossFormer/blob/main/models/crossformer.py.
+Modified from https://github.com/cheerss/CrossFormer/blob/main/models/crossformer.py
 """
 import numpy as np
 

--- a/flowvision/models/crossformer.py
+++ b/flowvision/models/crossformer.py
@@ -92,10 +92,10 @@ class Attention(nn.Module):
         dim (int): Number of input channels
         group_size (tuple[int]): The height and width of the group
         num_heads (int): Number of attention heads
-        qkv_bias (bool, optional):  If True, add a learnable bias to query, key, value. Default: True
+        qkv_bias (bool, optional):  If True, add a learnable bias to query, key, value. Default: ``True``
         qk_scale (float | None, optional): Override default qk scale of head_dim ** -0.5 if set
-        attn_drop (float, optional): Dropout ratio of attention weight. Default: 0.0
-        proj_drop (float, optional): Dropout ratio of output. Default: 0.0
+        attn_drop (float, optional): Dropout ratio of attention weight. Default: ``0.0``
+        proj_drop (float, optional): Dropout ratio of output. Default: ``0.0``
     """
 
     def __init__(
@@ -217,13 +217,13 @@ class CrossFormerBlock(nn.Module):
         group_size (int): Group size
         lsda_flag (int): use SDA or LDA, 0 for SDA and 1 for LDA
         mlp_ratio (float): Ratio of mlp hidden dim to embedding dim
-        qkv_bias (bool, optional): If True, add a learnable bias to query, key, value. Default: True
+        qkv_bias (bool, optional): If True, add a learnable bias to query, key, value. Default: ``True``
         qk_scale (float | None, optional): Override default qk scale of head_dim ** -0.5 if set
-        drop (float, optional): Dropout rate. Default: 0.0
-        attn_drop (float, optional): Attention dropout rate. Default: 0.0
-        drop_path (float, optional): Stochastic depth rate. Default: 0.0
-        act_layer (nn.Module, optional): Activation layer. Default: nn.GELU
-        norm_layer (nn.Module, optional): Normalization layer.  Default: nn.LayerNorm
+        drop (float, optional): Dropout rate. Default: ``0.0``
+        attn_drop (float, optional): Attention dropout rate. Default: ``0.0``
+        drop_path (float, optional): Stochastic depth rate. Default: ``0.0``
+        act_layer (nn.Module, optional): Activation layer. Default: ``nn.GELU``
+        norm_layer (nn.Module, optional): Normalization layer.  Default: ``nn.LayerNorm``
     """
 
     def __init__(
@@ -322,7 +322,7 @@ class PatchMerging(nn.Module):
     Args:
         input_resolution (tuple[int]): Resolution of input feature
         dim (int): Number of input channels
-        norm_layer (nn.Module, optional): Normalization layer. Default: nn.LayerNorm
+        norm_layer (nn.Module, optional): Normalization layer. Default: ``nn.LayerNorm``
     """
 
     def __init__(
@@ -380,13 +380,13 @@ class Stage(nn.Module):
         num_heads (int): Number of attention heads
         group_size (int): variable G in the paper, one group has GxG embeddings
         mlp_ratio (float): Ratio of mlp hidden dim to embedding dim
-        qkv_bias (bool, optional): If True, add a learnable bias to query, key, value. Default: True
+        qkv_bias (bool, optional): If True, add a learnable bias to query, key, value. Default: ``True``
         qk_scale (float | None, optional): Override default qk scale of head_dim ** -0.5 if set
-        drop (float, optional): Dropout rate. Default: 0.0
-        attn_drop (float, optional): Attention dropout rate. Default: 0.0
-        drop_path (float | tuple[float], optional): Stochastic depth rate. Default: 0.0
-        norm_layer (nn.Module, optional): Normalization layer. Default: nn.LayerNorm
-        downsample (nn.Module | None, optional): Downsample layer at the end of the layer. Default: None
+        drop (float, optional): Dropout rate. Default: ``0.0``
+        attn_drop (float, optional): Attention dropout rate. Default: ``0.0``
+        drop_path (float | tuple[float], optional): Stochastic depth rate. Default: ``0.0``
+        norm_layer (nn.Module, optional): Normalization layer. Default: ``nn.LayerNorm``
+        downsample (nn.Module | None, optional): Downsample layer at the end of the layer. Default: ``None``
     """
 
     def __init__(
@@ -463,11 +463,11 @@ class Stage(nn.Module):
 class PatchEmbed(nn.Module):
     r""" Image to Patch Embedding
     Args:
-        img_size (int): Image size.  Default: 224
-        patch_size (int): Patch token size. Default: [4]
-        in_chans (int): Number of input image channels. Default: 3
-        embed_dim (int): Number of linear projection output channels. Default: 96
-        norm_layer (nn.Module, optional): Normalization layer. Default: None
+        img_size (int): Image size.  Default: ``224``
+        patch_size (int): Patch token size. Default: ``[4]``
+        in_chans (int): Number of input image channels. Default: ``3``
+        embed_dim (int): Number of linear projection output channels. Default: ``96``
+        norm_layer (nn.Module, optional): Normalization layer. Default: ``None``
     """
 
     def __init__(
@@ -524,24 +524,24 @@ class CrossFormer(nn.Module):
     r""" CrossFormer
         A OneFlow impl of : `CrossFormer: A Versatile Vision Transformer Based on Cross-scale Attention`  -
     Args:
-        img_size (int | tuple(int)): Input image size. Default 224
-        patch_size (int | tuple(int)): Patch size. Default: 4
-        in_chans (int): Number of input image channels. Default: 3
-        num_classes (int): Number of classes for classification head. Default: 1000
-        embed_dim (int): Patch embedding dimension. Default: 96
-        depths (tuple(int)): Depth of each stage.
-        num_heads (tuple(int)): Number of attention heads in different layers.
-        group_size (int): Group size. Default: 7
-        mlp_ratio (float): Ratio of mlp hidden dim to embedding dim. Default: 4
-        qkv_bias (bool): If True, add a learnable bias to query, key, value. Default: True
-        qk_scale (float): Override default qk scale of head_dim ** -0.5 if set. Default: None
-        drop_rate (float): Dropout rate. Default: 0
-        attn_drop_rate (float): Attention dropout rate. Default: 0
-        drop_path_rate (float): Stochastic depth rate. Default: 0.1
-        norm_layer (nn.Module): Normalization layer. Default: nn.LayerNorm
-        ape (bool): If True, add absolute position embedding to the patch embedding. Default: False
-        patch_norm (bool): If True, add normalization after patch embedding. Default: True
-        use_checkpoint (bool): Whether to use checkpointing to save memory. Default: False
+        img_size (int | tuple(int)): Input image size. Default: ``224``
+        patch_size (int | tuple(int)): Patch size. Default: ``4``
+        in_chans (int): Number of input image channels. Default: ``3``
+        num_classes (int): Number of classes for classification head. Default: ``1000``
+        embed_dim (int): Patch embedding dimension. Default: ``96``
+        depths (tuple(int)): Depth of each stage
+        num_heads (tuple(int)): Number of attention heads in different layers
+        group_size (int): Group size. Default: ``7``
+        mlp_ratio (float): Ratio of mlp hidden dim to embedding dim. Default: ``4``
+        qkv_bias (bool): If True, add a learnable bias to query, key, value. Default: ``True``
+        qk_scale (float): Override default qk scale of head_dim ** -0.5 if set. Default: ``None``
+        drop_rate (float): Dropout rate. Default: ``0``
+        attn_drop_rate (float): Attention dropout rate. Default: ``0``
+        drop_path_rate (float): Stochastic depth rate. Default: ``0.1``
+        norm_layer (nn.Module): Normalization layer. Default: ``nn.LayerNorm``
+        ape (bool): If True, add absolute position embedding to the patch embedding. Default: ``False``
+        patch_norm (bool): If True, add normalization after patch embedding. Default: ``True``
+        use_checkpoint (bool): Whether to use checkpointing to save memory. Default: ``False``
     """
 
     def __init__(

--- a/flowvision/models/crossformer.py
+++ b/flowvision/models/crossformer.py
@@ -89,13 +89,13 @@ class DynamicPosBias(nn.Module):
 class Attention(nn.Module):
     r""" Multi-head self attention module with dynamic position bias.
     Args:
-        dim (int): Number of input channels.
-        group_size (tuple[int]): The height and width of the group.
-        num_heads (int): Number of attention heads.
+        dim (int): Number of input channels
+        group_size (tuple[int]): The height and width of the group
+        num_heads (int): Number of attention heads
         qkv_bias (bool, optional):  If True, add a learnable bias to query, key, value. Default: True
         qk_scale (float | None, optional): Override default qk scale of head_dim ** -0.5 if set
         attn_drop (float, optional): Dropout ratio of attention weight. Default: 0.0
-        proj_drop (float, optional): Dropout ratio of output. Default: 0.0
+        proj_drop (float, optional): Dropout ratio of output. Default: 0.0.
     """
 
     def __init__(
@@ -161,7 +161,7 @@ class Attention(nn.Module):
         """
         Args:
             x: input features with shape of (num_groups*B, N, C)
-            mask: (0/-inf) mask with shape of (num_groups, Wh*Ww, Wh*Ww) or None
+            mask: (0/-inf) mask with shape of (num_groups, Wh*Ww, Wh*Ww) or None.
         """
         B_, N, C = x.shape
         qkv = (
@@ -211,19 +211,19 @@ class Attention(nn.Module):
 class CrossFormerBlock(nn.Module):
     r""" CrossFormer Block.
     Args:
-        dim (int): Number of input channels.
-        input_resolution (tuple[int]): Input resulotion.
-        num_heads (int): Number of attention heads.
-        group_size (int): Group size.
-        lsda_flag (int): use SDA or LDA, 0 for SDA and 1 for LDA.
-        mlp_ratio (float): Ratio of mlp hidden dim to embedding dim.
+        dim (int): Number of input channels
+        input_resolution (tuple[int]): Input resulotion
+        num_heads (int): Number of attention heads
+        group_size (int): Group size
+        lsda_flag (int): use SDA or LDA, 0 for SDA and 1 for LDA
+        mlp_ratio (float): Ratio of mlp hidden dim to embedding dim
         qkv_bias (bool, optional): If True, add a learnable bias to query, key, value. Default: True
-        qk_scale (float | None, optional): Override default qk scale of head_dim ** -0.5 if set.
+        qk_scale (float | None, optional): Override default qk scale of head_dim ** -0.5 if set
         drop (float, optional): Dropout rate. Default: 0.0
         attn_drop (float, optional): Attention dropout rate. Default: 0.0
         drop_path (float, optional): Stochastic depth rate. Default: 0.0
         act_layer (nn.Module, optional): Activation layer. Default: nn.GELU
-        norm_layer (nn.Module, optional): Normalization layer.  Default: nn.LayerNorm
+        norm_layer (nn.Module, optional): Normalization layer.  Default: nn.LayerNorm.
     """
 
     def __init__(
@@ -320,9 +320,9 @@ class CrossFormerBlock(nn.Module):
 class PatchMerging(nn.Module):
     r""" Patch Merging Layer.
     Args:
-        input_resolution (tuple[int]): Resolution of input feature.
-        dim (int): Number of input channels.
-        norm_layer (nn.Module, optional): Normalization layer.  Default: nn.LayerNorm
+        input_resolution (tuple[int]): Resolution of input feature
+        dim (int): Number of input channels
+        norm_layer (nn.Module, optional): Normalization layer. Default: nn.LayerNorm.
     """
 
     def __init__(
@@ -374,19 +374,19 @@ class PatchMerging(nn.Module):
 class Stage(nn.Module):
     """ CrossFormer blocks for one stage.
     Args:
-        dim (int): Number of input channels.
-        input_resolution (tuple[int]): Input resolution.
-        depth (int): Number of blocks.
-        num_heads (int): Number of attention heads.
+        dim (int): Number of input channels
+        input_resolution (tuple[int]): Input resolution
+        depth (int): Number of blocks
+        num_heads (int): Number of attention heads
         group_size (int): variable G in the paper, one group has GxG embeddings
-        mlp_ratio (float): Ratio of mlp hidden dim to embedding dim.
+        mlp_ratio (float): Ratio of mlp hidden dim to embedding dim
         qkv_bias (bool, optional): If True, add a learnable bias to query, key, value. Default: True
-        qk_scale (float | None, optional): Override default qk scale of head_dim ** -0.5 if set.
+        qk_scale (float | None, optional): Override default qk scale of head_dim ** -0.5 if set
         drop (float, optional): Dropout rate. Default: 0.0
         attn_drop (float, optional): Attention dropout rate. Default: 0.0
         drop_path (float | tuple[float], optional): Stochastic depth rate. Default: 0.0
         norm_layer (nn.Module, optional): Normalization layer. Default: nn.LayerNorm
-        downsample (nn.Module | None, optional): Downsample layer at the end of the layer. Default: None
+        downsample (nn.Module | None, optional): Downsample layer at the end of the layer. Default: None.
     """
 
     def __init__(
@@ -463,11 +463,11 @@ class Stage(nn.Module):
 class PatchEmbed(nn.Module):
     r""" Image to Patch Embedding
     Args:
-        img_size (int): Image size.  Default: 224.
-        patch_size (int): Patch token size. Default: [4].
-        in_chans (int): Number of input image channels. Default: 3.
-        embed_dim (int): Number of linear projection output channels. Default: 96.
-        norm_layer (nn.Module, optional): Normalization layer. Default: None
+        img_size (int): Image size.  Default: 224
+        patch_size (int): Patch token size. Default: [4]
+        in_chans (int): Number of input image channels. Default: 3
+        embed_dim (int): Number of linear projection output channels. Default: 96
+        norm_layer (nn.Module, optional): Normalization layer. Default: None.
     """
 
     def __init__(
@@ -538,10 +538,10 @@ class CrossFormer(nn.Module):
         drop_rate (float): Dropout rate. Default: 0
         attn_drop_rate (float): Attention dropout rate. Default: 0
         drop_path_rate (float): Stochastic depth rate. Default: 0.1
-        norm_layer (nn.Module): Normalization layer. Default: nn.LayerNorm.
+        norm_layer (nn.Module): Normalization layer. Default: nn.LayerNorm
         ape (bool): If True, add absolute position embedding to the patch embedding. Default: False
         patch_norm (bool): If True, add normalization after patch embedding. Default: True
-        use_checkpoint (bool): Whether to use checkpointing to save memory. Default: False
+        use_checkpoint (bool): Whether to use checkpointing to save memory. Default: False.
     """
 
     def __init__(
@@ -692,7 +692,7 @@ def crossformer_tiny_patch4_group7_224(pretrained=False, progress=True, **kwargs
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -731,7 +731,7 @@ def crossformer_small_patch4_group7_224(pretrained=False, progress=True, **kwarg
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -770,7 +770,7 @@ def crossformer_base_patch4_group7_224(pretrained=False, progress=True, **kwargs
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -809,7 +809,7 @@ def crossformer_large_patch4_group7_224(pretrained=False, progress=True, **kwarg
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 

--- a/flowvision/models/crossformer.py
+++ b/flowvision/models/crossformer.py
@@ -692,7 +692,7 @@ def crossformer_tiny_patch4_group7_224(pretrained=False, progress=True, **kwargs
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -731,7 +731,7 @@ def crossformer_small_patch4_group7_224(pretrained=False, progress=True, **kwarg
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -770,7 +770,7 @@ def crossformer_base_patch4_group7_224(pretrained=False, progress=True, **kwargs
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -809,7 +809,7 @@ def crossformer_large_patch4_group7_224(pretrained=False, progress=True, **kwarg
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 

--- a/flowvision/models/crossformer.py
+++ b/flowvision/models/crossformer.py
@@ -160,7 +160,7 @@ class Attention(nn.Module):
     def forward(self, x, mask=None):
         """
         Args:
-            x: input features with shape of (num_groups*B, N, C)
+            x: Input features with shape of (num_groups*B, N, C)
             mask: (0/-inf) mask with shape of (num_groups, Wh*Ww, Wh*Ww) or None
         """
         B_, N, C = x.shape
@@ -215,7 +215,7 @@ class CrossFormerBlock(nn.Module):
         input_resolution (tuple[int]): Input resulotion
         num_heads (int): Number of attention heads
         group_size (int): Group size
-        lsda_flag (int): use SDA or LDA, 0 for SDA and 1 for LDA
+        lsda_flag (int): Use SDA or LDA, 0 for SDA and 1 for LDA
         mlp_ratio (float): Ratio of mlp hidden dim to embedding dim
         qkv_bias (bool, optional): If True, add a learnable bias to query, key, value. Default: ``True``
         qk_scale (float | None, optional): Override default qk scale of head_dim ** -0.5 if set
@@ -378,7 +378,7 @@ class Stage(nn.Module):
         input_resolution (tuple[int]): Input resolution
         depth (int): Number of blocks
         num_heads (int): Number of attention heads
-        group_size (int): variable G in the paper, one group has GxG embeddings
+        group_size (int): Variable G in the paper, one group has GxG embeddings
         mlp_ratio (float): Ratio of mlp hidden dim to embedding dim
         qkv_bias (bool, optional): If True, add a learnable bias to query, key, value. Default: ``True``
         qk_scale (float | None, optional): Override default qk scale of head_dim ** -0.5 if set

--- a/flowvision/models/crossformer.py
+++ b/flowvision/models/crossformer.py
@@ -95,7 +95,7 @@ class Attention(nn.Module):
         qkv_bias (bool, optional):  If True, add a learnable bias to query, key, value. Default: True
         qk_scale (float | None, optional): Override default qk scale of head_dim ** -0.5 if set
         attn_drop (float, optional): Dropout ratio of attention weight. Default: 0.0
-        proj_drop (float, optional): Dropout ratio of output. Default: 0.0.
+        proj_drop (float, optional): Dropout ratio of output. Default: 0.0
     """
 
     def __init__(
@@ -161,7 +161,7 @@ class Attention(nn.Module):
         """
         Args:
             x: input features with shape of (num_groups*B, N, C)
-            mask: (0/-inf) mask with shape of (num_groups, Wh*Ww, Wh*Ww) or None.
+            mask: (0/-inf) mask with shape of (num_groups, Wh*Ww, Wh*Ww) or None
         """
         B_, N, C = x.shape
         qkv = (
@@ -223,7 +223,7 @@ class CrossFormerBlock(nn.Module):
         attn_drop (float, optional): Attention dropout rate. Default: 0.0
         drop_path (float, optional): Stochastic depth rate. Default: 0.0
         act_layer (nn.Module, optional): Activation layer. Default: nn.GELU
-        norm_layer (nn.Module, optional): Normalization layer.  Default: nn.LayerNorm.
+        norm_layer (nn.Module, optional): Normalization layer.  Default: nn.LayerNorm
     """
 
     def __init__(
@@ -322,7 +322,7 @@ class PatchMerging(nn.Module):
     Args:
         input_resolution (tuple[int]): Resolution of input feature
         dim (int): Number of input channels
-        norm_layer (nn.Module, optional): Normalization layer. Default: nn.LayerNorm.
+        norm_layer (nn.Module, optional): Normalization layer. Default: nn.LayerNorm
     """
 
     def __init__(
@@ -386,7 +386,7 @@ class Stage(nn.Module):
         attn_drop (float, optional): Attention dropout rate. Default: 0.0
         drop_path (float | tuple[float], optional): Stochastic depth rate. Default: 0.0
         norm_layer (nn.Module, optional): Normalization layer. Default: nn.LayerNorm
-        downsample (nn.Module | None, optional): Downsample layer at the end of the layer. Default: None.
+        downsample (nn.Module | None, optional): Downsample layer at the end of the layer. Default: None
     """
 
     def __init__(
@@ -467,7 +467,7 @@ class PatchEmbed(nn.Module):
         patch_size (int): Patch token size. Default: [4]
         in_chans (int): Number of input image channels. Default: 3
         embed_dim (int): Number of linear projection output channels. Default: 96
-        norm_layer (nn.Module, optional): Normalization layer. Default: None.
+        norm_layer (nn.Module, optional): Normalization layer. Default: None
     """
 
     def __init__(
@@ -541,7 +541,7 @@ class CrossFormer(nn.Module):
         norm_layer (nn.Module): Normalization layer. Default: nn.LayerNorm
         ape (bool): If True, add absolute position embedding to the patch embedding. Default: False
         patch_norm (bool): If True, add normalization after patch embedding. Default: True
-        use_checkpoint (bool): Whether to use checkpointing to save memory. Default: False.
+        use_checkpoint (bool): Whether to use checkpointing to save memory. Default: False
     """
 
     def __init__(
@@ -692,7 +692,7 @@ def crossformer_tiny_patch4_group7_224(pretrained=False, progress=True, **kwargs
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -731,7 +731,7 @@ def crossformer_small_patch4_group7_224(pretrained=False, progress=True, **kwarg
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -770,7 +770,7 @@ def crossformer_base_patch4_group7_224(pretrained=False, progress=True, **kwargs
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -809,7 +809,7 @@ def crossformer_large_patch4_group7_224(pretrained=False, progress=True, **kwarg
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 

--- a/flowvision/models/crossformer.py
+++ b/flowvision/models/crossformer.py
@@ -1,5 +1,5 @@
 """
-Modified from https://github.com/cheerss/CrossFormer/blob/main/models/crossformer.py
+Modified from https://github.com/cheerss/CrossFormer/blob/main/models/crossformer.py.
 """
 import numpy as np
 

--- a/flowvision/models/cswin.py
+++ b/flowvision/models/cswin.py
@@ -521,7 +521,7 @@ def cswin_tiny_224(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -555,7 +555,7 @@ def cswin_small_224(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -589,7 +589,7 @@ def cswin_base_224(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -623,7 +623,7 @@ def cswin_large_224(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -657,7 +657,7 @@ def cswin_base_384(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -692,7 +692,7 @@ def cswin_large_384(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 

--- a/flowvision/models/cswin.py
+++ b/flowvision/models/cswin.py
@@ -521,7 +521,7 @@ def cswin_tiny_224(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -555,7 +555,7 @@ def cswin_small_224(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -589,7 +589,7 @@ def cswin_base_224(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -623,7 +623,7 @@ def cswin_large_224(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -657,7 +657,7 @@ def cswin_base_384(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -692,7 +692,7 @@ def cswin_large_384(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 

--- a/flowvision/models/cswin.py
+++ b/flowvision/models/cswin.py
@@ -521,7 +521,7 @@ def cswin_tiny_224(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -555,7 +555,7 @@ def cswin_small_224(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -589,7 +589,7 @@ def cswin_base_224(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -623,7 +623,7 @@ def cswin_large_224(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -657,7 +657,7 @@ def cswin_base_384(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -692,7 +692,7 @@ def cswin_large_384(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 

--- a/flowvision/models/cswin.py
+++ b/flowvision/models/cswin.py
@@ -1,5 +1,5 @@
 """
-Modified from https://github.com/microsoft/CSWin-Transformer/blob/main/models/cswin.py.
+Modified from https://github.com/microsoft/CSWin-Transformer/blob/main/models/cswin.py
 """
 import math
 import numpy as np

--- a/flowvision/models/cswin.py
+++ b/flowvision/models/cswin.py
@@ -1,5 +1,5 @@
 """
-Modified from https://github.com/microsoft/CSWin-Transformer/blob/main/models/cswin.py
+Modified from https://github.com/microsoft/CSWin-Transformer/blob/main/models/cswin.py.
 """
 import math
 import numpy as np

--- a/flowvision/models/densenet.py
+++ b/flowvision/models/densenet.py
@@ -1,5 +1,5 @@
 """
-Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/densenet.py.
+Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/densenet.py
 """
 from collections import OrderedDict
 from typing import Any, List, Tuple

--- a/flowvision/models/densenet.py
+++ b/flowvision/models/densenet.py
@@ -154,7 +154,7 @@ class DenseNet(nn.Module):
         bn_size (int) - multiplicative factor for number of bottle neck layers
           (i.e. bn_size * k features in the bottleneck layer)
         drop_rate (float) - dropout rate after each dense layer
-        num_classes (int) - number of classification classes.
+        num_classes (int) - number of classification classes
     """
 
     def __init__(
@@ -283,7 +283,7 @@ def densenet121(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -311,7 +311,7 @@ def densenet161(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -339,7 +339,7 @@ def densenet169(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -367,7 +367,7 @@ def densenet201(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 

--- a/flowvision/models/densenet.py
+++ b/flowvision/models/densenet.py
@@ -148,13 +148,13 @@ class DenseNet(nn.Module):
     r"""Densenet-BC model class, based on
     `"Densely Connected Convolutional Networks" <https://arxiv.org/pdf/1608.06993.pdf>`_.
     Args:
-        growth_rate (int) - how many filters to add each layer (`k` in paper)
-        block_config (list of 4 ints) - how many layers in each pooling block
-        num_init_features (int) - the number of filters to learn in the first convolution layer
-        bn_size (int) - multiplicative factor for number of bottle neck layers
+        growth_rate (int) - How many filters to add each layer (`k` in paper)
+        block_config (list of 4 ints) - How many layers in each pooling block
+        num_init_features (int) - The number of filters to learn in the first convolution layer
+        bn_size (int) - Multiplicative factor for number of bottle neck layers
           (i.e. bn_size * k features in the bottleneck layer)
-        drop_rate (float) - dropout rate after each dense layer
-        num_classes (int) - number of classification classes
+        drop_rate (float) - Dropout rate after each dense layer
+        num_classes (int) - Number of classification classes
     """
 
     def __init__(

--- a/flowvision/models/densenet.py
+++ b/flowvision/models/densenet.py
@@ -283,7 +283,7 @@ def densenet121(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -311,7 +311,7 @@ def densenet161(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -339,7 +339,7 @@ def densenet169(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -367,7 +367,7 @@ def densenet201(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 

--- a/flowvision/models/densenet.py
+++ b/flowvision/models/densenet.py
@@ -154,7 +154,7 @@ class DenseNet(nn.Module):
         bn_size (int) - multiplicative factor for number of bottle neck layers
           (i.e. bn_size * k features in the bottleneck layer)
         drop_rate (float) - dropout rate after each dense layer
-        num_classes (int) - number of classification classes
+        num_classes (int) - number of classification classes.
     """
 
     def __init__(
@@ -283,7 +283,7 @@ def densenet121(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -311,7 +311,7 @@ def densenet161(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -339,7 +339,7 @@ def densenet169(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -367,7 +367,7 @@ def densenet201(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 

--- a/flowvision/models/densenet.py
+++ b/flowvision/models/densenet.py
@@ -1,5 +1,5 @@
 """
-Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/densenet.py
+Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/densenet.py.
 """
 from collections import OrderedDict
 from typing import Any, List, Tuple

--- a/flowvision/models/densenet.py
+++ b/flowvision/models/densenet.py
@@ -148,13 +148,13 @@ class DenseNet(nn.Module):
     r"""Densenet-BC model class, based on
     `"Densely Connected Convolutional Networks" <https://arxiv.org/pdf/1608.06993.pdf>`_.
     Args:
-        growth_rate (int) - How many filters to add each layer (`k` in paper)
-        block_config (list of 4 ints) - How many layers in each pooling block
-        num_init_features (int) - The number of filters to learn in the first convolution layer
-        bn_size (int) - Multiplicative factor for number of bottle neck layers
+        growth_rate (int): How many filters to add each layer (`k` in paper)
+        block_config (list of 4 ints): How many layers in each pooling block
+        num_init_features (int): The number of filters to learn in the first convolution layer
+        bn_size (int): Multiplicative factor for number of bottle neck layers
           (i.e. bn_size * k features in the bottleneck layer)
-        drop_rate (float) - Dropout rate after each dense layer
-        num_classes (int) - Number of classification classes
+        drop_rate (float): Dropout rate after each dense layer
+        num_classes (int): Number of classification classes
     """
 
     def __init__(

--- a/flowvision/models/efficientnet.py
+++ b/flowvision/models/efficientnet.py
@@ -1,5 +1,5 @@
 """
-Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/efficientnet.py
+Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/efficientnet.py.
 """
 import copy
 import math

--- a/flowvision/models/efficientnet.py
+++ b/flowvision/models/efficientnet.py
@@ -365,7 +365,7 @@ def efficientnet_b0(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -393,7 +393,7 @@ def efficientnet_b1(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -421,7 +421,7 @@ def efficientnet_b2(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -449,7 +449,7 @@ def efficientnet_b3(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -477,7 +477,7 @@ def efficientnet_b4(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -505,7 +505,7 @@ def efficientnet_b5(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -540,7 +540,7 @@ def efficientnet_b6(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -575,7 +575,7 @@ def efficientnet_b7(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 

--- a/flowvision/models/efficientnet.py
+++ b/flowvision/models/efficientnet.py
@@ -1,5 +1,5 @@
 """
-Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/efficientnet.py.
+Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/efficientnet.py
 """
 import copy
 import math

--- a/flowvision/models/efficientnet.py
+++ b/flowvision/models/efficientnet.py
@@ -50,7 +50,7 @@ class SqueezeExcitation(nn.Module):
         input_channels (int): Number of channels in the input image
         squeeze_channels (int): Number of squeeze channels
         activation (Callable[..., flow.nn.Module], optional): ``delta`` activation. Default: ``flow.nn.ReLU``
-        scale_activation (Callable[..., flow.nn.Module]): ``sigma`` activation. Default: ``flow.nn.Sigmoid``
+        scale_activation (Callable[..., flow.nn.Module]): ``sigma`` activation. Default: ``flow.nn.Sigmoid``.
     """
 
     def __init__(
@@ -218,7 +218,7 @@ class EfficientNet(nn.Module):
             stochastic_depth_prob (float): The stochastic depth probability
             num_classes (int): Number of classes
             block (Optional[Callable[..., nn.Module]]): Module specifying inverted residual building block for mobilenet
-            norm_layer (Optional[Callable[..., nn.Module]]): Module specifying the normalization layer to use
+            norm_layer (Optional[Callable[..., nn.Module]]): Module specifying the normalization layer to use.
         """
         super().__init__()
 
@@ -365,7 +365,7 @@ def efficientnet_b0(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -393,7 +393,7 @@ def efficientnet_b1(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -421,7 +421,7 @@ def efficientnet_b2(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -449,7 +449,7 @@ def efficientnet_b3(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -477,7 +477,7 @@ def efficientnet_b4(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -505,7 +505,7 @@ def efficientnet_b5(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -540,7 +540,7 @@ def efficientnet_b6(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -575,7 +575,7 @@ def efficientnet_b7(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 

--- a/flowvision/models/efficientnet.py
+++ b/flowvision/models/efficientnet.py
@@ -50,7 +50,7 @@ class SqueezeExcitation(nn.Module):
         input_channels (int): Number of channels in the input image
         squeeze_channels (int): Number of squeeze channels
         activation (Callable[..., flow.nn.Module], optional): ``delta`` activation. Default: ``flow.nn.ReLU``
-        scale_activation (Callable[..., flow.nn.Module]): ``sigma`` activation. Default: ``flow.nn.Sigmoid``.
+        scale_activation (Callable[..., flow.nn.Module]): ``sigma`` activation. Default: ``flow.nn.Sigmoid``
     """
 
     def __init__(
@@ -218,7 +218,7 @@ class EfficientNet(nn.Module):
             stochastic_depth_prob (float): The stochastic depth probability
             num_classes (int): Number of classes
             block (Optional[Callable[..., nn.Module]]): Module specifying inverted residual building block for mobilenet
-            norm_layer (Optional[Callable[..., nn.Module]]): Module specifying the normalization layer to use.
+            norm_layer (Optional[Callable[..., nn.Module]]): Module specifying the normalization layer to use
         """
         super().__init__()
 
@@ -365,7 +365,7 @@ def efficientnet_b0(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -393,7 +393,7 @@ def efficientnet_b1(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -421,7 +421,7 @@ def efficientnet_b2(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -449,7 +449,7 @@ def efficientnet_b3(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -477,7 +477,7 @@ def efficientnet_b4(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -505,7 +505,7 @@ def efficientnet_b5(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -540,7 +540,7 @@ def efficientnet_b6(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -575,7 +575,7 @@ def efficientnet_b7(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 

--- a/flowvision/models/ghostnet.py
+++ b/flowvision/models/ghostnet.py
@@ -1,5 +1,5 @@
 """
-Modified from https://github.com/iamhankai/ghostnet.pytorch/blob/master/ghost_net.py
+Modified from https://github.com/iamhankai/ghostnet.pytorch/blob/master/ghost_net.py.
 """
 import math
 from typing import Any

--- a/flowvision/models/ghostnet.py
+++ b/flowvision/models/ghostnet.py
@@ -283,7 +283,7 @@ def ghostnet(pretrained: bool = False, progress: bool = True, **kwargs: Any):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 

--- a/flowvision/models/ghostnet.py
+++ b/flowvision/models/ghostnet.py
@@ -283,7 +283,7 @@ def ghostnet(pretrained: bool = False, progress: bool = True, **kwargs: Any):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 

--- a/flowvision/models/ghostnet.py
+++ b/flowvision/models/ghostnet.py
@@ -1,5 +1,5 @@
 """
-Modified from https://github.com/iamhankai/ghostnet.pytorch/blob/master/ghost_net.py.
+Modified from https://github.com/iamhankai/ghostnet.pytorch/blob/master/ghost_net.py
 """
 import math
 from typing import Any

--- a/flowvision/models/ghostnet.py
+++ b/flowvision/models/ghostnet.py
@@ -283,7 +283,7 @@ def ghostnet(pretrained: bool = False, progress: bool = True, **kwargs: Any):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 

--- a/flowvision/models/googlenet.py
+++ b/flowvision/models/googlenet.py
@@ -1,5 +1,5 @@
 """
-Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/googlenet.py.
+Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/googlenet.py
 """
 import warnings
 from collections import namedtuple

--- a/flowvision/models/googlenet.py
+++ b/flowvision/models/googlenet.py
@@ -48,9 +48,9 @@ def googlenet(
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
         progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
         aux_logits (bool): If True, adds two auxiliary branches that can improve training.
-            Default: *False* when pretrained is True otherwise *True*
+            Default: ``False`` when pretrained is True otherwise ``True``
         transform_input (bool): If True, preprocesses the input according to the method with which it
-            was trained on ImageNet. Default: *False*.
+            was trained on ImageNet. Default: ``False``.
 
     For example:
 

--- a/flowvision/models/googlenet.py
+++ b/flowvision/models/googlenet.py
@@ -46,7 +46,7 @@ def googlenet(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
         aux_logits (bool): If True, adds two auxiliary branches that can improve training.
             Default: *False* when pretrained is True otherwise *True*
         transform_input (bool): If True, preprocesses the input according to the method with which it

--- a/flowvision/models/googlenet.py
+++ b/flowvision/models/googlenet.py
@@ -1,5 +1,5 @@
 """
-Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/googlenet.py
+Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/googlenet.py.
 """
 import warnings
 from collections import namedtuple

--- a/flowvision/models/googlenet.py
+++ b/flowvision/models/googlenet.py
@@ -50,7 +50,7 @@ def googlenet(
         aux_logits (bool): If True, adds two auxiliary branches that can improve training.
             Default: *False* when pretrained is True otherwise *True*
         transform_input (bool): If True, preprocesses the input according to the method with which it
-            was trained on ImageNet. Default: *False*
+            was trained on ImageNet. Default: *False*.
 
     For example:
 

--- a/flowvision/models/googlenet.py
+++ b/flowvision/models/googlenet.py
@@ -50,7 +50,7 @@ def googlenet(
         aux_logits (bool): If True, adds two auxiliary branches that can improve training.
             Default: ``False`` when pretrained is True otherwise ``True``
         transform_input (bool): If True, preprocesses the input according to the method with which it
-            was trained on ImageNet. Default: ``False``.
+            was trained on ImageNet. Default: ``False``
 
     For example:
 

--- a/flowvision/models/inception_v3.py
+++ b/flowvision/models/inception_v3.py
@@ -39,7 +39,7 @@ def inception_v3(pretrained: bool = False, progress: bool = True, **kwargs: Any)
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
         aux_logits (bool): If True, add an auxiliary branch that can improve training.
             Default: *True*
         transform_input (bool): If True, preprocesses the input according to the method with which it

--- a/flowvision/models/inception_v3.py
+++ b/flowvision/models/inception_v3.py
@@ -41,9 +41,9 @@ def inception_v3(pretrained: bool = False, progress: bool = True, **kwargs: Any)
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
         progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
         aux_logits (bool): If True, add an auxiliary branch that can improve training.
-            Default: *True*
+            Default: ``True``
         transform_input (bool): If True, preprocesses the input according to the method with which it
-            was trained on ImageNet. Default: *False*.
+            was trained on ImageNet. Default: ``False``.
 
     For example:
 

--- a/flowvision/models/inception_v3.py
+++ b/flowvision/models/inception_v3.py
@@ -1,5 +1,5 @@
 """
-Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/inception.py
+Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/inception.py.
 """
 import warnings
 from collections import namedtuple

--- a/flowvision/models/inception_v3.py
+++ b/flowvision/models/inception_v3.py
@@ -43,7 +43,7 @@ def inception_v3(pretrained: bool = False, progress: bool = True, **kwargs: Any)
         aux_logits (bool): If True, add an auxiliary branch that can improve training.
             Default: *True*
         transform_input (bool): If True, preprocesses the input according to the method with which it
-            was trained on ImageNet. Default: *False*
+            was trained on ImageNet. Default: *False*.
 
     For example:
 

--- a/flowvision/models/inception_v3.py
+++ b/flowvision/models/inception_v3.py
@@ -43,7 +43,7 @@ def inception_v3(pretrained: bool = False, progress: bool = True, **kwargs: Any)
         aux_logits (bool): If True, add an auxiliary branch that can improve training.
             Default: ``True``
         transform_input (bool): If True, preprocesses the input according to the method with which it
-            was trained on ImageNet. Default: ``False``.
+            was trained on ImageNet. Default: ``False``
 
     For example:
 

--- a/flowvision/models/inception_v3.py
+++ b/flowvision/models/inception_v3.py
@@ -1,5 +1,5 @@
 """
-Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/inception.py.
+Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/inception.py
 """
 import warnings
 from collections import namedtuple

--- a/flowvision/models/mlp_mixer.py
+++ b/flowvision/models/mlp_mixer.py
@@ -332,7 +332,7 @@ def mlp_mixer_s16_224(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -358,7 +358,7 @@ def mlp_mixer_s32_224(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -384,7 +384,7 @@ def mlp_mixer_b16_224(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -410,7 +410,7 @@ def mlp_mixer_b32_224(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -437,7 +437,7 @@ def mlp_mixer_b16_224_in21k(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -468,7 +468,7 @@ def mlp_mixer_l16_224(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -494,7 +494,7 @@ def mlp_mixer_l32_224(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -521,7 +521,7 @@ def mlp_mixer_l16_224_in21k(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -553,7 +553,7 @@ def mlp_mixer_b16_224_miil(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -583,7 +583,7 @@ def mlp_mixer_b16_224_miil_in21k(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -614,7 +614,7 @@ def gmlp_ti16_224(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -648,7 +648,7 @@ def gmlp_s16_224(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -682,7 +682,7 @@ def gmlp_b16_224(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 

--- a/flowvision/models/mlp_mixer.py
+++ b/flowvision/models/mlp_mixer.py
@@ -332,7 +332,7 @@ def mlp_mixer_s16_224(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -358,7 +358,7 @@ def mlp_mixer_s32_224(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -384,7 +384,7 @@ def mlp_mixer_b16_224(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -410,7 +410,7 @@ def mlp_mixer_b32_224(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -437,7 +437,7 @@ def mlp_mixer_b16_224_in21k(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -468,7 +468,7 @@ def mlp_mixer_l16_224(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -494,7 +494,7 @@ def mlp_mixer_l32_224(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -521,7 +521,7 @@ def mlp_mixer_l16_224_in21k(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -553,7 +553,7 @@ def mlp_mixer_b16_224_miil(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -583,7 +583,7 @@ def mlp_mixer_b16_224_miil_in21k(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -614,7 +614,7 @@ def gmlp_ti16_224(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -648,7 +648,7 @@ def gmlp_s16_224(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -682,7 +682,7 @@ def gmlp_b16_224(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 

--- a/flowvision/models/mlp_mixer.py
+++ b/flowvision/models/mlp_mixer.py
@@ -332,7 +332,7 @@ def mlp_mixer_s16_224(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -358,7 +358,7 @@ def mlp_mixer_s32_224(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -384,7 +384,7 @@ def mlp_mixer_b16_224(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -410,7 +410,7 @@ def mlp_mixer_b32_224(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -437,7 +437,7 @@ def mlp_mixer_b16_224_in21k(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -468,7 +468,7 @@ def mlp_mixer_l16_224(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -494,7 +494,7 @@ def mlp_mixer_l32_224(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -521,7 +521,7 @@ def mlp_mixer_l16_224_in21k(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -553,7 +553,7 @@ def mlp_mixer_b16_224_miil(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -583,7 +583,7 @@ def mlp_mixer_b16_224_miil_in21k(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -614,7 +614,7 @@ def gmlp_ti16_224(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -648,7 +648,7 @@ def gmlp_s16_224(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -682,7 +682,7 @@ def gmlp_b16_224(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 

--- a/flowvision/models/mnasnet.py
+++ b/flowvision/models/mnasnet.py
@@ -181,7 +181,7 @@ def mnasnet0_5(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -207,7 +207,7 @@ def mnasnet0_75(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -233,7 +233,7 @@ def mnasnet1_0(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -259,7 +259,7 @@ def mnasnet1_3(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 

--- a/flowvision/models/mnasnet.py
+++ b/flowvision/models/mnasnet.py
@@ -1,5 +1,5 @@
 """
-Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/mnasnet.py
+Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/mnasnet.py.
 """
 import math
 import warnings

--- a/flowvision/models/mnasnet.py
+++ b/flowvision/models/mnasnet.py
@@ -181,7 +181,7 @@ def mnasnet0_5(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -207,7 +207,7 @@ def mnasnet0_75(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -233,7 +233,7 @@ def mnasnet1_0(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -259,7 +259,7 @@ def mnasnet1_3(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 

--- a/flowvision/models/mnasnet.py
+++ b/flowvision/models/mnasnet.py
@@ -1,5 +1,5 @@
 """
-Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/mnasnet.py.
+Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/mnasnet.py
 """
 import math
 import warnings

--- a/flowvision/models/mnasnet.py
+++ b/flowvision/models/mnasnet.py
@@ -181,7 +181,7 @@ def mnasnet0_5(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -207,7 +207,7 @@ def mnasnet0_75(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -233,7 +233,7 @@ def mnasnet1_0(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -259,7 +259,7 @@ def mnasnet1_3(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 

--- a/flowvision/models/mobilenet.py
+++ b/flowvision/models/mobilenet.py
@@ -1,5 +1,5 @@
 """
-Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/mobilenet.py
+Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/mobilenet.py.
 """
 from .mobilenet_v2 import MobileNetV2, mobilenet_v2, __all__ as mv2_all
 from .mobilenet_v3 import (

--- a/flowvision/models/mobilenet.py
+++ b/flowvision/models/mobilenet.py
@@ -1,5 +1,5 @@
 """
-Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/mobilenet.py.
+Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/mobilenet.py
 """
 from .mobilenet_v2 import MobileNetV2, mobilenet_v2, __all__ as mv2_all
 from .mobilenet_v3 import (

--- a/flowvision/models/mobilenet_v2.py
+++ b/flowvision/models/mobilenet_v2.py
@@ -143,7 +143,7 @@ class MobileNetV2(nn.Module):
             round_nearest (int): Round the number of channels in each layer to be a multiple of this number
             Set to 1 to turn off rounding
             block: Module specifying inverted residual building block for mobilenet
-            norm_layer: Module specifying the normalization layer to use.
+            norm_layer: Module specifying the normalization layer to use
         """
         super(MobileNetV2, self).__init__()
 
@@ -254,7 +254,7 @@ def mobilenet_v2(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 

--- a/flowvision/models/mobilenet_v2.py
+++ b/flowvision/models/mobilenet_v2.py
@@ -254,7 +254,7 @@ def mobilenet_v2(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 

--- a/flowvision/models/mobilenet_v2.py
+++ b/flowvision/models/mobilenet_v2.py
@@ -143,7 +143,7 @@ class MobileNetV2(nn.Module):
             round_nearest (int): Round the number of channels in each layer to be a multiple of this number
             Set to 1 to turn off rounding
             block: Module specifying inverted residual building block for mobilenet
-            norm_layer: Module specifying the normalization layer to use
+            norm_layer: Module specifying the normalization layer to use.
         """
         super(MobileNetV2, self).__init__()
 
@@ -254,7 +254,7 @@ def mobilenet_v2(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 

--- a/flowvision/models/mobilenet_v2.py
+++ b/flowvision/models/mobilenet_v2.py
@@ -1,5 +1,5 @@
 """
-Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/mobilenetv2.py.
+Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/mobilenetv2.py
 """
 import math
 from typing import Callable, Any, Optional, List

--- a/flowvision/models/mobilenet_v2.py
+++ b/flowvision/models/mobilenet_v2.py
@@ -1,5 +1,5 @@
 """
-Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/mobilenetv2.py
+Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/mobilenetv2.py.
 """
 import math
 from typing import Callable, Any, Optional, List

--- a/flowvision/models/mobilenet_v2.py
+++ b/flowvision/models/mobilenet_v2.py
@@ -140,7 +140,7 @@ class MobileNetV2(nn.Module):
             num_classes (int): Number of classes
             width_mult (float): Width multiplier - adjusts number of channels in each layer by this amount
             inverted_residual_setting: Network structure
-            round_nearest (int): Round the number of channels in each layer to be a multiple of this number
+            round_nearest (int): Round the number of channels in each layer to be a multiple of this number.
             Set to 1 to turn off rounding
             block: Module specifying inverted residual building block for mobilenet
             norm_layer: Module specifying the normalization layer to use

--- a/flowvision/models/mobilenet_v3.py
+++ b/flowvision/models/mobilenet_v3.py
@@ -1,5 +1,5 @@
 """
-Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/mobilenetv3.py
+Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/mobilenetv3.py.
 """
 from functools import partial
 from typing import Any, Callable, Dict, List, Optional, Sequence

--- a/flowvision/models/mobilenet_v3.py
+++ b/flowvision/models/mobilenet_v3.py
@@ -207,7 +207,7 @@ class MobileNetV3(nn.Module):
             last_channel (int): The number of channels on the penultimate layer
             num_classes (int): Number of classes
             block (Optional[Callable[..., nn.Module]]): Module specifying inverted residual building block for mobilenet
-            norm_layer (Optional[Callable[..., nn.Module]]): Module specifying the normalization layer to use.
+            norm_layer (Optional[Callable[..., nn.Module]]): Module specifying the normalization layer to use
         """
         super().__init__()
 
@@ -423,7 +423,7 @@ def mobilenet_v3_large(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -452,7 +452,7 @@ def mobilenet_v3_small(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 

--- a/flowvision/models/mobilenet_v3.py
+++ b/flowvision/models/mobilenet_v3.py
@@ -207,7 +207,7 @@ class MobileNetV3(nn.Module):
             last_channel (int): The number of channels on the penultimate layer
             num_classes (int): Number of classes
             block (Optional[Callable[..., nn.Module]]): Module specifying inverted residual building block for mobilenet
-            norm_layer (Optional[Callable[..., nn.Module]]): Module specifying the normalization layer to use
+            norm_layer (Optional[Callable[..., nn.Module]]): Module specifying the normalization layer to use.
         """
         super().__init__()
 
@@ -423,7 +423,7 @@ def mobilenet_v3_large(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -452,7 +452,7 @@ def mobilenet_v3_small(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 

--- a/flowvision/models/mobilenet_v3.py
+++ b/flowvision/models/mobilenet_v3.py
@@ -423,7 +423,7 @@ def mobilenet_v3_large(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -452,7 +452,7 @@ def mobilenet_v3_small(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 

--- a/flowvision/models/mobilenet_v3.py
+++ b/flowvision/models/mobilenet_v3.py
@@ -1,5 +1,5 @@
 """
-Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/mobilenetv3.py.
+Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/mobilenetv3.py
 """
 from functools import partial
 from typing import Any, Callable, Dict, List, Optional, Sequence

--- a/flowvision/models/neural_style_transfer/stylenet.py
+++ b/flowvision/models/neural_style_transfer/stylenet.py
@@ -138,7 +138,7 @@ def neural_style_transfer(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
         style_model (str): Which pretrained style model to download, user can choose from [sketch, candy, mosaic, rain_princess, udnie]. Default: ``sketch``
 
     For example:

--- a/flowvision/models/pvt.py
+++ b/flowvision/models/pvt.py
@@ -366,7 +366,7 @@ def pvt_tiny(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -404,7 +404,7 @@ def pvt_small(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -442,7 +442,7 @@ def pvt_medium(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -480,7 +480,7 @@ def pvt_large(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 

--- a/flowvision/models/pvt.py
+++ b/flowvision/models/pvt.py
@@ -1,5 +1,5 @@
 """
-Modified from https://github.com/whai362/PVT/blob/v2/classification/pvt.py
+Modified from https://github.com/whai362/PVT/blob/v2/classification/pvt.py.
 """
 import numpy as np
 from functools import partial

--- a/flowvision/models/pvt.py
+++ b/flowvision/models/pvt.py
@@ -1,5 +1,5 @@
 """
-Modified from https://github.com/whai362/PVT/blob/v2/classification/pvt.py.
+Modified from https://github.com/whai362/PVT/blob/v2/classification/pvt.py
 """
 import numpy as np
 from functools import partial

--- a/flowvision/models/pvt.py
+++ b/flowvision/models/pvt.py
@@ -366,7 +366,7 @@ def pvt_tiny(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -404,7 +404,7 @@ def pvt_small(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -442,7 +442,7 @@ def pvt_medium(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -480,7 +480,7 @@ def pvt_large(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 

--- a/flowvision/models/pvt.py
+++ b/flowvision/models/pvt.py
@@ -366,7 +366,7 @@ def pvt_tiny(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -404,7 +404,7 @@ def pvt_small(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -442,7 +442,7 @@ def pvt_medium(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -480,7 +480,7 @@ def pvt_large(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 

--- a/flowvision/models/registry.py
+++ b/flowvision/models/registry.py
@@ -1,5 +1,5 @@
 """
-Modified from https://github.com/rwightman/pytorch-image-models/blob/master/timm/models/registry.py.
+Modified from https://github.com/rwightman/pytorch-image-models/blob/master/timm/models/registry.py
 """
 import sys
 import re

--- a/flowvision/models/registry.py
+++ b/flowvision/models/registry.py
@@ -1,5 +1,5 @@
 """
-Modified from https://github.com/rwightman/pytorch-image-models/blob/master/timm/models/registry.py
+Modified from https://github.com/rwightman/pytorch-image-models/blob/master/timm/models/registry.py.
 """
 import sys
 import re

--- a/flowvision/models/res2net.py
+++ b/flowvision/models/res2net.py
@@ -210,7 +210,7 @@ def res2net50_26w_4s(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -238,7 +238,7 @@ def res2net101_26w_4s(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -266,7 +266,7 @@ def res2net50_26w_6s(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -294,7 +294,7 @@ def res2net50_26w_8s(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -322,7 +322,7 @@ def res2net50_48w_2s(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -350,7 +350,7 @@ def res2net50_14w_8s(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 

--- a/flowvision/models/res2net.py
+++ b/flowvision/models/res2net.py
@@ -1,5 +1,5 @@
 """
-Modified from https://github.com/Res2Net/Res2Net-PretrainedModels/blob/master/res2net.py.
+Modified from https://github.com/Res2Net/Res2Net-PretrainedModels/blob/master/res2net.py
 """
 import math
 

--- a/flowvision/models/res2net.py
+++ b/flowvision/models/res2net.py
@@ -38,10 +38,10 @@ class Bottle2neck(nn.Module):
         Args:
             inplanes: input channel dimensionality
             planes: output channel dimensionality
-            stride: conv stride. Replaces pooling layer.
+            stride: conv stride. Replaces pooling layer
             downsample: None when stride = 1
             baseWidth: basic width of conv3x3
-            scale: number of scale.
+            scale: number of scale
             type: 'normal': normal set. 'stage': first block of a new stage.
         """
         super(Bottle2neck, self).__init__()
@@ -210,7 +210,7 @@ def res2net50_26w_4s(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -238,7 +238,7 @@ def res2net101_26w_4s(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -266,7 +266,7 @@ def res2net50_26w_6s(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -294,7 +294,7 @@ def res2net50_26w_8s(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -322,7 +322,7 @@ def res2net50_48w_2s(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -350,7 +350,7 @@ def res2net50_14w_8s(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 

--- a/flowvision/models/res2net.py
+++ b/flowvision/models/res2net.py
@@ -36,12 +36,12 @@ class Bottle2neck(nn.Module):
     ):
         """ Constructor
         Args:
-            inplanes: input channel dimensionality
-            planes: output channel dimensionality
-            stride: conv stride. Replaces pooling layer
+            inplanes: Input channel dimensionality
+            planes: Output channel dimensionality
+            stride: Conv stride. Replaces pooling layer
             downsample: None when stride = 1
-            baseWidth: basic width of conv3x3
-            scale: number of scale
+            baseWidth: Basic width of conv3x3
+            scale: Number of scale
             type: 'normal': normal set. 'stage': first block of a new stage
         """
         super(Bottle2neck, self).__init__()

--- a/flowvision/models/res2net.py
+++ b/flowvision/models/res2net.py
@@ -42,7 +42,7 @@ class Bottle2neck(nn.Module):
             downsample: None when stride = 1
             baseWidth: basic width of conv3x3
             scale: number of scale
-            type: 'normal': normal set. 'stage': first block of a new stage.
+            type: 'normal': normal set. 'stage': first block of a new stage
         """
         super(Bottle2neck, self).__init__()
 
@@ -210,7 +210,7 @@ def res2net50_26w_4s(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -238,7 +238,7 @@ def res2net101_26w_4s(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -266,7 +266,7 @@ def res2net50_26w_6s(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -294,7 +294,7 @@ def res2net50_26w_8s(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -322,7 +322,7 @@ def res2net50_48w_2s(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -350,7 +350,7 @@ def res2net50_14w_8s(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 

--- a/flowvision/models/res2net.py
+++ b/flowvision/models/res2net.py
@@ -1,5 +1,5 @@
 """
-Modified from https://github.com/Res2Net/Res2Net-PretrainedModels/blob/master/res2net.py
+Modified from https://github.com/Res2Net/Res2Net-PretrainedModels/blob/master/res2net.py.
 """
 import math
 

--- a/flowvision/models/res2net.py
+++ b/flowvision/models/res2net.py
@@ -42,7 +42,7 @@ class Bottle2neck(nn.Module):
             downsample: None when stride = 1
             baseWidth: Basic width of conv3x3
             scale: Number of scale
-            type: 'normal': normal set. 'stage': first block of a new stage
+            stype: 'normal': normal set. 'stage': first block of a new stage
         """
         super(Bottle2neck, self).__init__()
 

--- a/flowvision/models/res_mlp.py
+++ b/flowvision/models/res_mlp.py
@@ -175,7 +175,7 @@ def resmlp_12(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -209,7 +209,7 @@ def resmlp_12_dist(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -242,7 +242,7 @@ def resmlp_24(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -276,7 +276,7 @@ def resmlp_24_dist(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -310,7 +310,7 @@ def resmlp_24_dino(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -343,7 +343,7 @@ def resmlp_36(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -377,7 +377,7 @@ def resmlp_36_dist(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -410,7 +410,7 @@ def resmlpB_24(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -444,7 +444,7 @@ def resmlpB_24_in22k(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -478,7 +478,7 @@ def resmlpB_24_dist(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 

--- a/flowvision/models/res_mlp.py
+++ b/flowvision/models/res_mlp.py
@@ -1,5 +1,5 @@
 """
-Modified from https://github.com/facebookresearch/deit/blob/main/resmlp_models.py
+Modified from https://github.com/facebookresearch/deit/blob/main/resmlp_models.py.
 """
 import oneflow as flow
 import oneflow.nn as nn

--- a/flowvision/models/res_mlp.py
+++ b/flowvision/models/res_mlp.py
@@ -175,7 +175,7 @@ def resmlp_12(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -209,7 +209,7 @@ def resmlp_12_dist(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -242,7 +242,7 @@ def resmlp_24(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -276,7 +276,7 @@ def resmlp_24_dist(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -310,7 +310,7 @@ def resmlp_24_dino(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -343,7 +343,7 @@ def resmlp_36(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -377,7 +377,7 @@ def resmlp_36_dist(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -410,7 +410,7 @@ def resmlpB_24(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -444,7 +444,7 @@ def resmlpB_24_in22k(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -478,7 +478,7 @@ def resmlpB_24_dist(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 

--- a/flowvision/models/res_mlp.py
+++ b/flowvision/models/res_mlp.py
@@ -1,5 +1,5 @@
 """
-Modified from https://github.com/facebookresearch/deit/blob/main/resmlp_models.py.
+Modified from https://github.com/facebookresearch/deit/blob/main/resmlp_models.py
 """
 import oneflow as flow
 import oneflow.nn as nn

--- a/flowvision/models/res_mlp.py
+++ b/flowvision/models/res_mlp.py
@@ -175,7 +175,7 @@ def resmlp_12(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -205,11 +205,11 @@ def resmlp_12_dist(pretrained=False, progress=True, **kwargs):
 
     .. note::
         ResMLP-12 model with distillation from `"ResMLP: Feedforward networks for image classification with data-efficient training" <https://arxiv.org/pdf/2105.03404.pdf>`_.
-        Note that tht model is the same as resmlp_12 but the pretrained weight is different.
+        Note that this model is the same as resmlp_12 but the pretrained weight is different.
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -242,7 +242,7 @@ def resmlp_24(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -272,11 +272,11 @@ def resmlp_24_dist(pretrained=False, progress=True, **kwargs):
 
     .. note::
         ResMLP-24 model with distillation from `"ResMLP: Feedforward networks for image classification with data-efficient training" <https://arxiv.org/pdf/2105.03404.pdf>`_.
-        Note that tht model is the same as resmlp_24 but the pretrained weight is different.
+        Note that this model is the same as resmlp_24 but the pretrained weight is different.
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -306,11 +306,11 @@ def resmlp_24_dino(pretrained=False, progress=True, **kwargs):
 
     .. note::
         ResMLP-24 model with distillation from `"ResMLP: Feedforward networks for image classification with data-efficient training" <https://arxiv.org/pdf/2105.03404.pdf>`_.
-        Note that tht model is the same as resmlp_24 but the pretrained weight is different.
+        Note that this model is the same as resmlp_24 but the pretrained weight is different.
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -343,7 +343,7 @@ def resmlp_36(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -373,11 +373,11 @@ def resmlp_36_dist(pretrained=False, progress=True, **kwargs):
 
     .. note::
         ResMLP-36 model with distillation from `"ResMLP: Feedforward networks for image classification with data-efficient training" <https://arxiv.org/pdf/2105.03404.pdf>`_.
-        Note that tht model is the same as resmlp_36 but the pretrained weight is different.
+        Note that this model is the same as resmlp_36 but the pretrained weight is different.
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -410,7 +410,7 @@ def resmlpB_24(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -440,11 +440,11 @@ def resmlpB_24_in22k(pretrained=False, progress=True, **kwargs):
 
     .. note::
         ImageNet22k pretrained ResMLP-B-24 model from `"ResMLP: Feedforward networks for image classification with data-efficient training" <https://arxiv.org/pdf/2105.03404.pdf>`_.
-        Note that tht model is the same as resmlpB_24 but the pretrained weight is different.
+        Note that this model is the same as resmlpB_24 but the pretrained weight is different.
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -474,11 +474,11 @@ def resmlpB_24_dist(pretrained=False, progress=True, **kwargs):
 
     .. note::
         ResMLP-B-24 model with distillation from `"ResMLP: Feedforward networks for image classification with data-efficient training" <https://arxiv.org/pdf/2105.03404.pdf>`_.
-        Note that tht model is the same as resmlpB_24 but the pretrained weight is different.
+        Note that this model is the same as resmlpB_24 but the pretrained weight is different.
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 

--- a/flowvision/models/resnet.py
+++ b/flowvision/models/resnet.py
@@ -1,5 +1,5 @@
 """
-Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/resnet.py.
+Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/resnet.py
 """
 from typing import Type, Any, Callable, Union, List, Optional
 

--- a/flowvision/models/resnet.py
+++ b/flowvision/models/resnet.py
@@ -1,5 +1,5 @@
 """
-Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/resnet.py
+Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/resnet.py.
 """
 from typing import Type, Any, Callable, Union, List, Optional
 

--- a/flowvision/models/resnet.py
+++ b/flowvision/models/resnet.py
@@ -319,7 +319,7 @@ def resnet18(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> 
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -342,7 +342,7 @@ def resnet34(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> 
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -365,7 +365,7 @@ def resnet50(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> 
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -388,7 +388,7 @@ def resnet101(pretrained: bool = False, progress: bool = True, **kwargs: Any) ->
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -413,7 +413,7 @@ def resnet152(pretrained: bool = False, progress: bool = True, **kwargs: Any) ->
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -440,7 +440,7 @@ def resnext50_32x4d(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -469,7 +469,7 @@ def resnext101_32x8d(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -502,7 +502,7 @@ def wide_resnet50_2(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -533,7 +533,7 @@ def wide_resnet101_2(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 

--- a/flowvision/models/resnet.py
+++ b/flowvision/models/resnet.py
@@ -319,7 +319,7 @@ def resnet18(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> 
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -342,7 +342,7 @@ def resnet34(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> 
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -365,7 +365,7 @@ def resnet50(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> 
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -388,7 +388,7 @@ def resnet101(pretrained: bool = False, progress: bool = True, **kwargs: Any) ->
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -413,7 +413,7 @@ def resnet152(pretrained: bool = False, progress: bool = True, **kwargs: Any) ->
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -440,7 +440,7 @@ def resnext50_32x4d(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -469,7 +469,7 @@ def resnext101_32x8d(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -502,7 +502,7 @@ def wide_resnet50_2(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -533,7 +533,7 @@ def wide_resnet101_2(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 

--- a/flowvision/models/resnet.py
+++ b/flowvision/models/resnet.py
@@ -319,7 +319,7 @@ def resnet18(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> 
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -342,7 +342,7 @@ def resnet34(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> 
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -365,7 +365,7 @@ def resnet50(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> 
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -388,7 +388,7 @@ def resnet101(pretrained: bool = False, progress: bool = True, **kwargs: Any) ->
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -413,7 +413,7 @@ def resnet152(pretrained: bool = False, progress: bool = True, **kwargs: Any) ->
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -440,7 +440,7 @@ def resnext50_32x4d(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -469,7 +469,7 @@ def resnext101_32x8d(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -502,7 +502,7 @@ def wide_resnet50_2(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -533,7 +533,7 @@ def wide_resnet101_2(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 

--- a/flowvision/models/rexnet.py
+++ b/flowvision/models/rexnet.py
@@ -1,5 +1,5 @@
 """
-Modified from https://github.com/clovaai/rexnet/blob/master/rexnetv1.py
+Modified from https://github.com/clovaai/rexnet/blob/master/rexnetv1.py.
 """
 from math import ceil
 

--- a/flowvision/models/rexnet.py
+++ b/flowvision/models/rexnet.py
@@ -1,5 +1,5 @@
 """
-Modified from https://github.com/clovaai/rexnet/blob/master/rexnetv1.py.
+Modified from https://github.com/clovaai/rexnet/blob/master/rexnetv1.py
 """
 from math import ceil
 

--- a/flowvision/models/rexnet.py
+++ b/flowvision/models/rexnet.py
@@ -236,7 +236,7 @@ def rexnetv1_1_0(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -262,7 +262,7 @@ def rexnetv1_1_3(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -314,7 +314,7 @@ def rexnetv1_2_0(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -340,7 +340,7 @@ def rexnetv1_3_0(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 

--- a/flowvision/models/rexnet.py
+++ b/flowvision/models/rexnet.py
@@ -236,7 +236,7 @@ def rexnetv1_1_0(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -262,7 +262,7 @@ def rexnetv1_1_3(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -288,7 +288,7 @@ def rexnetv1_1_5(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -314,7 +314,7 @@ def rexnetv1_2_0(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -340,7 +340,7 @@ def rexnetv1_3_0(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 

--- a/flowvision/models/rexnet.py
+++ b/flowvision/models/rexnet.py
@@ -236,7 +236,7 @@ def rexnetv1_1_0(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -262,7 +262,7 @@ def rexnetv1_1_3(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -314,7 +314,7 @@ def rexnetv1_2_0(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -340,7 +340,7 @@ def rexnetv1_3_0(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 

--- a/flowvision/models/rexnet_lite.py
+++ b/flowvision/models/rexnet_lite.py
@@ -1,5 +1,5 @@
 """
-Modified from https://github.com/clovaai/rexnet/blob/master/rexnetv1_lite.py
+Modified from https://github.com/clovaai/rexnet/blob/master/rexnetv1_lite.py.
 """
 import math
 

--- a/flowvision/models/rexnet_lite.py
+++ b/flowvision/models/rexnet_lite.py
@@ -248,7 +248,7 @@ def rexnet_lite_1_0(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -274,7 +274,7 @@ def rexnet_lite_1_3(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -300,7 +300,7 @@ def rexnet_lite_1_5(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -326,7 +326,7 @@ def rexnet_lite_2_0(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 

--- a/flowvision/models/rexnet_lite.py
+++ b/flowvision/models/rexnet_lite.py
@@ -248,7 +248,7 @@ def rexnet_lite_1_0(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -274,7 +274,7 @@ def rexnet_lite_1_3(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -300,7 +300,7 @@ def rexnet_lite_1_5(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -326,7 +326,7 @@ def rexnet_lite_2_0(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 

--- a/flowvision/models/rexnet_lite.py
+++ b/flowvision/models/rexnet_lite.py
@@ -1,5 +1,5 @@
 """
-Modified from https://github.com/clovaai/rexnet/blob/master/rexnetv1_lite.py.
+Modified from https://github.com/clovaai/rexnet/blob/master/rexnetv1_lite.py
 """
 import math
 

--- a/flowvision/models/rexnet_lite.py
+++ b/flowvision/models/rexnet_lite.py
@@ -248,7 +248,7 @@ def rexnet_lite_1_0(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -274,7 +274,7 @@ def rexnet_lite_1_3(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -300,7 +300,7 @@ def rexnet_lite_1_5(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -326,7 +326,7 @@ def rexnet_lite_2_0(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 

--- a/flowvision/models/shufflenet_v2.py
+++ b/flowvision/models/shufflenet_v2.py
@@ -219,7 +219,7 @@ def shufflenet_v2_x0_5(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -251,7 +251,7 @@ def shufflenet_v2_x1_0(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -283,7 +283,7 @@ def shufflenet_v2_x1_5(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -315,7 +315,7 @@ def shufflenet_v2_x2_0(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 

--- a/flowvision/models/shufflenet_v2.py
+++ b/flowvision/models/shufflenet_v2.py
@@ -219,7 +219,7 @@ def shufflenet_v2_x0_5(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -251,7 +251,7 @@ def shufflenet_v2_x1_0(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -283,7 +283,7 @@ def shufflenet_v2_x1_5(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -315,7 +315,7 @@ def shufflenet_v2_x2_0(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 

--- a/flowvision/models/shufflenet_v2.py
+++ b/flowvision/models/shufflenet_v2.py
@@ -1,5 +1,5 @@
 """
-Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/shufflenetv2.py
+Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/shufflenetv2.py.
 """
 from typing import Callable, Any, List
 

--- a/flowvision/models/shufflenet_v2.py
+++ b/flowvision/models/shufflenet_v2.py
@@ -1,5 +1,5 @@
 """
-Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/shufflenetv2.py.
+Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/shufflenetv2.py
 """
 from typing import Callable, Any, List
 

--- a/flowvision/models/shufflenet_v2.py
+++ b/flowvision/models/shufflenet_v2.py
@@ -219,7 +219,7 @@ def shufflenet_v2_x0_5(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -251,7 +251,7 @@ def shufflenet_v2_x1_0(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -283,7 +283,7 @@ def shufflenet_v2_x1_5(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -315,7 +315,7 @@ def shufflenet_v2_x2_0(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 

--- a/flowvision/models/squeezenet.py
+++ b/flowvision/models/squeezenet.py
@@ -140,7 +140,7 @@ def squeezenet1_0(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -166,7 +166,7 @@ def squeezenet1_1(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 

--- a/flowvision/models/squeezenet.py
+++ b/flowvision/models/squeezenet.py
@@ -1,5 +1,5 @@
 """
-Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/squeezenet.py
+Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/squeezenet.py.
 """
 from typing import Any
 

--- a/flowvision/models/squeezenet.py
+++ b/flowvision/models/squeezenet.py
@@ -1,5 +1,5 @@
 """
-Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/squeezenet.py.
+Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/squeezenet.py
 """
 from typing import Any
 

--- a/flowvision/models/squeezenet.py
+++ b/flowvision/models/squeezenet.py
@@ -140,7 +140,7 @@ def squeezenet1_0(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -166,7 +166,7 @@ def squeezenet1_1(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 

--- a/flowvision/models/squeezenet.py
+++ b/flowvision/models/squeezenet.py
@@ -140,7 +140,7 @@ def squeezenet1_0(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -166,7 +166,7 @@ def squeezenet1_1(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 

--- a/flowvision/models/swin_transformer.py
+++ b/flowvision/models/swin_transformer.py
@@ -109,10 +109,10 @@ class WindowAttention(nn.Module):
         dim (int): Number of input channels
         window_size (tuple[int]): The height and width of the window
         num_heads (int): Number of attention heads
-        qkv_bias (bool, optional):  If True, add a learnable bias to query, key, value. Default: True
+        qkv_bias (bool, optional):  If True, add a learnable bias to query, key, value. Default: ``True``
         qk_scale (float | None, optional): Override default qk scale of head_dim ** -0.5 if set
-        attn_drop (float, optional): Dropout ratio of attention weight. Default: 0.0
-        proj_drop (float, optional): Dropout ratio of output. Default: 0.0
+        attn_drop (float, optional): Dropout ratio of attention weight. Default: ``0.0``
+        proj_drop (float, optional): Dropout ratio of output. Default: ``0.0``
     """
 
     def __init__(
@@ -217,13 +217,13 @@ class SwinTransformerBlock(nn.Module):
         window_size (int): Window size
         shift_size (int): Shift size for SW-MSA
         mlp_ratio (float): Ratio of mlp hidden dim to embedding dim
-        qkv_bias (bool, optional): If True, add a learnable bias to query, key, value. Default: True
+        qkv_bias (bool, optional): If True, add a learnable bias to query, key, value. Default: ``True``
         qk_scale (float | None, optional): Override default qk scale of head_dim ** -0.5 if set
-        drop (float, optional): Dropout rate. Default: 0.0
-        attn_drop (float, optional): Attention dropout rate. Default: 0.0
-        drop_path (float, optional): Stochastic depth rate. Default: 0.0
-        act_layer (nn.Module, optional): Activation layer. Default: nn.GELU
-        norm_layer (nn.Module, optional): Normalization layer.  Default: nn.LayerNorm
+        drop (float, optional): Dropout rate. Default: ``0.0``
+        attn_drop (float, optional): Attention dropout rate. Default: ``0.0``
+        drop_path (float, optional): Stochastic depth rate. Default: ``0.0``
+        act_layer (nn.Module, optional): Activation layer. Default: ``nn.GELU``
+        norm_layer (nn.Module, optional): Normalization layer.  Default: ``nn.LayerNorm``
     """
 
     def __init__(
@@ -366,7 +366,7 @@ class PatchMerging(nn.Module):
     Args:
         input_resolution (tuple[int]): Resolution of input feature
         dim (int): Number of input channels
-        norm_layer (nn.Module, optional): Normalization layer.  Default: nn.LayerNorm
+        norm_layer (nn.Module, optional): Normalization layer.  Default: ``nn.LayerNorm``
     """
 
     def __init__(self, input_resolution, dim, norm_layer=nn.LayerNorm):
@@ -403,11 +403,11 @@ class PatchMerging(nn.Module):
 class PatchEmbed(nn.Module):
     r""" Image to Patch Embedding
     Args:
-        img_size (int): Image size.  Default: 224
-        patch_size (int): Patch token size. Default: 4
-        in_chans (int): Number of input image channels. Default: 3
-        embed_dim (int): Number of linear projection output channels. Default: 96
-        norm_layer (nn.Module, optional): Normalization layer. Default: None
+        img_size (int): Image size.  Default: ``224``
+        patch_size (int): Patch token size. Default: ``4``
+        in_chans (int): Number of input image channels. Default: ``3``
+        embed_dim (int): Number of linear projection output channels. Default: ``96``
+        norm_layer (nn.Module, optional): Normalization layer. Default: ``None``
     """
 
     def __init__(
@@ -457,14 +457,14 @@ class BasicLayer(nn.Module):
         num_heads (int): Number of attention heads
         window_size (int): Local window size
         mlp_ratio (float): Ratio of mlp hidden dim to embedding dim
-        qkv_bias (bool, optional): If True, add a learnable bias to query, key, value. Default: True
+        qkv_bias (bool, optional): If True, add a learnable bias to query, key, value. Default: ``True``
         qk_scale (float | None, optional): Override default qk scale of head_dim ** -0.5 if set
-        drop (float, optional): Dropout rate. Default: 0.0
-        attn_drop (float, optional): Attention dropout rate. Default: 0.0
-        drop_path (float | tuple[float], optional): Stochastic depth rate. Default: 0.0
-        norm_layer (nn.Module, optional): Normalization layer. Default: nn.LayerNorm
-        downsample (nn.Module | None, optional): Downsample layer at the end of the layer. Default: None
-        use_checkpoint (bool): Whether to use checkpointing to save memory. Default: False
+        drop (float, optional): Dropout rate. Default: ``0.0``
+        attn_drop (float, optional): Attention dropout rate. Default: ``0.0``
+        drop_path (float | tuple[float], optional): Stochastic depth rate. Default: ``0.0``
+        norm_layer (nn.Module, optional): Normalization layer. Default: ``nn.LayerNorm``
+        downsample (nn.Module | None, optional): Downsample layer at the end of the layer. Default: ``None``
+        use_checkpoint (bool): Whether to use checkpointing to save memory. Default: ``False``
     """
 
     def __init__(
@@ -539,24 +539,24 @@ class SwinTransformer(nn.Module):
         A PyTorch impl of : `Swin Transformer: Hierarchical Vision Transformer using Shifted Windows`  -
           https://arxiv.org/pdf/2103.14030
     Args:
-        img_size (int | tuple(int)): Input image size. Default 224
-        patch_size (int | tuple(int)): Patch size. Default: 4
-        in_chans (int): Number of input image channels. Default: 3
-        num_classes (int): Number of classes for classification head. Default: 1000
-        embed_dim (int): Patch embedding dimension. Default: 96
+        img_size (int | tuple(int)): Input image size. Default ``224``
+        patch_size (int | tuple(int)): Patch size. Default: ``4``
+        in_chans (int): Number of input image channels. Default: ``3``
+        num_classes (int): Number of classes for classification head. Default: ``1000``
+        embed_dim (int): Patch embedding dimension. Default: ``96``
         depths (tuple(int)): Depth of each Swin Transformer layer
         num_heads (tuple(int)): Number of attention heads in different layers
-        window_size (int): Window size. Default: 7
-        mlp_ratio (float): Ratio of mlp hidden dim to embedding dim. Default: 4
-        qkv_bias (bool): If True, add a learnable bias to query, key, value. Default: True
-        qk_scale (float): Override default qk scale of head_dim ** -0.5 if set. Default: None
-        drop_rate (float): Dropout rate. Default: 0
-        attn_drop_rate (float): Attention dropout rate. Default: 0
-        drop_path_rate (float): Stochastic depth rate. Default: 0.1
-        norm_layer (nn.Module): Normalization layer. Default: nn.LayerNorm.
-        ape (bool): If True, add absolute position embedding to the patch embedding. Default: False
-        patch_norm (bool): If True, add normalization after patch embedding. Default: True
-        use_checkpoint (bool): Whether to use checkpointing to save memory. Default: False
+        window_size (int): Window size. Default: ``7``
+        mlp_ratio (float): Ratio of mlp hidden dim to embedding dim. Default: ``4``
+        qkv_bias (bool): If True, add a learnable bias to query, key, value. Default: ``True``
+        qk_scale (float): Override default qk scale of head_dim ** -0.5 if set. Default: ``None``
+        drop_rate (float): Dropout rate. Default: ``0``
+        attn_drop_rate (float): Attention dropout rate. Default: ``0``
+        drop_path_rate (float): Stochastic depth rate. Default: ``0.1``
+        norm_layer (nn.Module): Normalization layer. Default: ``nn.LayerNorm``
+        ape (bool): If True, add absolute position embedding to the patch embedding. Default: ``False``
+        patch_norm (bool): If True, add normalization after patch embedding. Default: ``True``
+        use_checkpoint (bool): Whether to use checkpointing to save memory. Default: ``False``
     """
 
     def __init__(

--- a/flowvision/models/swin_transformer.py
+++ b/flowvision/models/swin_transformer.py
@@ -1,5 +1,5 @@
 """
-Modified from https://github.com/microsoft/Swin-Transformer/blob/main/models/swin_transformer.py
+Modified from https://github.com/microsoft/Swin-Transformer/blob/main/models/swin_transformer.py.
 """
 import numpy as np
 

--- a/flowvision/models/swin_transformer.py
+++ b/flowvision/models/swin_transformer.py
@@ -403,7 +403,7 @@ class PatchMerging(nn.Module):
 class PatchEmbed(nn.Module):
     r""" Image to Patch Embedding
     Args:
-        img_size (int): Image size.  Default: ``224``
+        img_size (int): Image size. Default: ``224``
         patch_size (int): Patch token size. Default: ``4``
         in_chans (int): Number of input image channels. Default: ``3``
         embed_dim (int): Number of linear projection output channels. Default: ``96``

--- a/flowvision/models/swin_transformer.py
+++ b/flowvision/models/swin_transformer.py
@@ -702,7 +702,7 @@ def swin_tiny_patch4_window7_224(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -740,7 +740,7 @@ def swin_small_patch4_window7_224(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -778,7 +778,7 @@ def swin_base_patch4_window7_224(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -816,7 +816,7 @@ def swin_base_patch4_window12_384(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -854,7 +854,7 @@ def swin_base_patch4_window7_224_in22k_to_1k(pretrained=False, progress=True, **
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -894,7 +894,7 @@ def swin_base_patch4_window12_384_in22k_to_1k(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -934,7 +934,7 @@ def swin_large_patch4_window7_224_in22k_to_1k(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -974,7 +974,7 @@ def swin_large_patch4_window12_384_in22k_to_1k(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 

--- a/flowvision/models/swin_transformer.py
+++ b/flowvision/models/swin_transformer.py
@@ -112,7 +112,7 @@ class WindowAttention(nn.Module):
         qkv_bias (bool, optional):  If True, add a learnable bias to query, key, value. Default: True
         qk_scale (float | None, optional): Override default qk scale of head_dim ** -0.5 if set
         attn_drop (float, optional): Dropout ratio of attention weight. Default: 0.0
-        proj_drop (float, optional): Dropout ratio of output. Default: 0.0.
+        proj_drop (float, optional): Dropout ratio of output. Default: 0.0
     """
 
     def __init__(
@@ -165,7 +165,7 @@ class WindowAttention(nn.Module):
         """
         Args:
             x: input features with shape of (num_windows*B, N, C)
-            mask: (0/-inf) mask with shape of (num_windows, Wh*Ww, Wh*Ww) or None.
+            mask: (0/-inf) mask with shape of (num_windows, Wh*Ww, Wh*Ww) or None
         """
         B_, N, C = x.shape
         qkv = (
@@ -223,7 +223,7 @@ class SwinTransformerBlock(nn.Module):
         attn_drop (float, optional): Attention dropout rate. Default: 0.0
         drop_path (float, optional): Stochastic depth rate. Default: 0.0
         act_layer (nn.Module, optional): Activation layer. Default: nn.GELU
-        norm_layer (nn.Module, optional): Normalization layer.  Default: nn.LayerNorm.
+        norm_layer (nn.Module, optional): Normalization layer.  Default: nn.LayerNorm
     """
 
     def __init__(
@@ -366,7 +366,7 @@ class PatchMerging(nn.Module):
     Args:
         input_resolution (tuple[int]): Resolution of input feature
         dim (int): Number of input channels
-        norm_layer (nn.Module, optional): Normalization layer.  Default: nn.LayerNorm.
+        norm_layer (nn.Module, optional): Normalization layer.  Default: nn.LayerNorm
     """
 
     def __init__(self, input_resolution, dim, norm_layer=nn.LayerNorm):
@@ -407,7 +407,7 @@ class PatchEmbed(nn.Module):
         patch_size (int): Patch token size. Default: 4
         in_chans (int): Number of input image channels. Default: 3
         embed_dim (int): Number of linear projection output channels. Default: 96
-        norm_layer (nn.Module, optional): Normalization layer. Default: None.
+        norm_layer (nn.Module, optional): Normalization layer. Default: None
     """
 
     def __init__(
@@ -464,7 +464,7 @@ class BasicLayer(nn.Module):
         drop_path (float | tuple[float], optional): Stochastic depth rate. Default: 0.0
         norm_layer (nn.Module, optional): Normalization layer. Default: nn.LayerNorm
         downsample (nn.Module | None, optional): Downsample layer at the end of the layer. Default: None
-        use_checkpoint (bool): Whether to use checkpointing to save memory. Default: False.
+        use_checkpoint (bool): Whether to use checkpointing to save memory. Default: False
     """
 
     def __init__(
@@ -556,7 +556,7 @@ class SwinTransformer(nn.Module):
         norm_layer (nn.Module): Normalization layer. Default: nn.LayerNorm.
         ape (bool): If True, add absolute position embedding to the patch embedding. Default: False
         patch_norm (bool): If True, add normalization after patch embedding. Default: True
-        use_checkpoint (bool): Whether to use checkpointing to save memory. Default: False.
+        use_checkpoint (bool): Whether to use checkpointing to save memory. Default: False
     """
 
     def __init__(
@@ -702,7 +702,7 @@ def swin_tiny_patch4_window7_224(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -740,7 +740,7 @@ def swin_small_patch4_window7_224(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -778,7 +778,7 @@ def swin_base_patch4_window7_224(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -816,7 +816,7 @@ def swin_base_patch4_window12_384(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -854,7 +854,7 @@ def swin_base_patch4_window7_224_in22k_to_1k(pretrained=False, progress=True, **
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -894,7 +894,7 @@ def swin_base_patch4_window12_384_in22k_to_1k(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -934,7 +934,7 @@ def swin_large_patch4_window7_224_in22k_to_1k(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -974,7 +974,7 @@ def swin_large_patch4_window12_384_in22k_to_1k(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 

--- a/flowvision/models/swin_transformer.py
+++ b/flowvision/models/swin_transformer.py
@@ -1,5 +1,5 @@
 """
-Modified from https://github.com/microsoft/Swin-Transformer/blob/main/models/swin_transformer.py.
+Modified from https://github.com/microsoft/Swin-Transformer/blob/main/models/swin_transformer.py
 """
 import numpy as np
 

--- a/flowvision/models/swin_transformer.py
+++ b/flowvision/models/swin_transformer.py
@@ -106,13 +106,13 @@ class WindowAttention(nn.Module):
     r""" Window based multi-head self attention (W-MSA) module with relative position bias.
     It supports both of shifted and non-shifted window.
     Args:
-        dim (int): Number of input channels.
-        window_size (tuple[int]): The height and width of the window.
-        num_heads (int): Number of attention heads.
+        dim (int): Number of input channels
+        window_size (tuple[int]): The height and width of the window
+        num_heads (int): Number of attention heads
         qkv_bias (bool, optional):  If True, add a learnable bias to query, key, value. Default: True
         qk_scale (float | None, optional): Override default qk scale of head_dim ** -0.5 if set
         attn_drop (float, optional): Dropout ratio of attention weight. Default: 0.0
-        proj_drop (float, optional): Dropout ratio of output. Default: 0.0
+        proj_drop (float, optional): Dropout ratio of output. Default: 0.0.
     """
 
     def __init__(
@@ -165,7 +165,7 @@ class WindowAttention(nn.Module):
         """
         Args:
             x: input features with shape of (num_windows*B, N, C)
-            mask: (0/-inf) mask with shape of (num_windows, Wh*Ww, Wh*Ww) or None
+            mask: (0/-inf) mask with shape of (num_windows, Wh*Ww, Wh*Ww) or None.
         """
         B_, N, C = x.shape
         qkv = (
@@ -211,19 +211,19 @@ class WindowAttention(nn.Module):
 class SwinTransformerBlock(nn.Module):
     r""" Swin Transformer Block.
     Args:
-        dim (int): Number of input channels.
-        input_resolution (tuple[int]): Input resulotion.
-        num_heads (int): Number of attention heads.
-        window_size (int): Window size.
-        shift_size (int): Shift size for SW-MSA.
-        mlp_ratio (float): Ratio of mlp hidden dim to embedding dim.
+        dim (int): Number of input channels
+        input_resolution (tuple[int]): Input resulotion
+        num_heads (int): Number of attention heads
+        window_size (int): Window size
+        shift_size (int): Shift size for SW-MSA
+        mlp_ratio (float): Ratio of mlp hidden dim to embedding dim
         qkv_bias (bool, optional): If True, add a learnable bias to query, key, value. Default: True
-        qk_scale (float | None, optional): Override default qk scale of head_dim ** -0.5 if set.
+        qk_scale (float | None, optional): Override default qk scale of head_dim ** -0.5 if set
         drop (float, optional): Dropout rate. Default: 0.0
         attn_drop (float, optional): Attention dropout rate. Default: 0.0
         drop_path (float, optional): Stochastic depth rate. Default: 0.0
         act_layer (nn.Module, optional): Activation layer. Default: nn.GELU
-        norm_layer (nn.Module, optional): Normalization layer.  Default: nn.LayerNorm
+        norm_layer (nn.Module, optional): Normalization layer.  Default: nn.LayerNorm.
     """
 
     def __init__(
@@ -364,9 +364,9 @@ class SwinTransformerBlock(nn.Module):
 class PatchMerging(nn.Module):
     r""" Patch Merging Layer.
     Args:
-        input_resolution (tuple[int]): Resolution of input feature.
-        dim (int): Number of input channels.
-        norm_layer (nn.Module, optional): Normalization layer.  Default: nn.LayerNorm
+        input_resolution (tuple[int]): Resolution of input feature
+        dim (int): Number of input channels
+        norm_layer (nn.Module, optional): Normalization layer.  Default: nn.LayerNorm.
     """
 
     def __init__(self, input_resolution, dim, norm_layer=nn.LayerNorm):
@@ -403,11 +403,11 @@ class PatchMerging(nn.Module):
 class PatchEmbed(nn.Module):
     r""" Image to Patch Embedding
     Args:
-        img_size (int): Image size.  Default: 224.
-        patch_size (int): Patch token size. Default: 4.
-        in_chans (int): Number of input image channels. Default: 3.
-        embed_dim (int): Number of linear projection output channels. Default: 96.
-        norm_layer (nn.Module, optional): Normalization layer. Default: None
+        img_size (int): Image size.  Default: 224
+        patch_size (int): Patch token size. Default: 4
+        in_chans (int): Number of input image channels. Default: 3
+        embed_dim (int): Number of linear projection output channels. Default: 96
+        norm_layer (nn.Module, optional): Normalization layer. Default: None.
     """
 
     def __init__(
@@ -451,14 +451,14 @@ class PatchEmbed(nn.Module):
 class BasicLayer(nn.Module):
     """ A basic Swin Transformer layer for one stage.
     Args:
-        dim (int): Number of input channels.
-        input_resolution (tuple[int]): Input resolution.
-        depth (int): Number of blocks.
-        num_heads (int): Number of attention heads.
-        window_size (int): Local window size.
-        mlp_ratio (float): Ratio of mlp hidden dim to embedding dim.
+        dim (int): Number of input channels
+        input_resolution (tuple[int]): Input resolution
+        depth (int): Number of blocks
+        num_heads (int): Number of attention heads
+        window_size (int): Local window size
+        mlp_ratio (float): Ratio of mlp hidden dim to embedding dim
         qkv_bias (bool, optional): If True, add a learnable bias to query, key, value. Default: True
-        qk_scale (float | None, optional): Override default qk scale of head_dim ** -0.5 if set.
+        qk_scale (float | None, optional): Override default qk scale of head_dim ** -0.5 if set
         drop (float, optional): Dropout rate. Default: 0.0
         attn_drop (float, optional): Attention dropout rate. Default: 0.0
         drop_path (float | tuple[float], optional): Stochastic depth rate. Default: 0.0
@@ -544,8 +544,8 @@ class SwinTransformer(nn.Module):
         in_chans (int): Number of input image channels. Default: 3
         num_classes (int): Number of classes for classification head. Default: 1000
         embed_dim (int): Patch embedding dimension. Default: 96
-        depths (tuple(int)): Depth of each Swin Transformer layer.
-        num_heads (tuple(int)): Number of attention heads in different layers.
+        depths (tuple(int)): Depth of each Swin Transformer layer
+        num_heads (tuple(int)): Number of attention heads in different layers
         window_size (int): Window size. Default: 7
         mlp_ratio (float): Ratio of mlp hidden dim to embedding dim. Default: 4
         qkv_bias (bool): If True, add a learnable bias to query, key, value. Default: True
@@ -556,7 +556,7 @@ class SwinTransformer(nn.Module):
         norm_layer (nn.Module): Normalization layer. Default: nn.LayerNorm.
         ape (bool): If True, add absolute position embedding to the patch embedding. Default: False
         patch_norm (bool): If True, add normalization after patch embedding. Default: True
-        use_checkpoint (bool): Whether to use checkpointing to save memory. Default: False
+        use_checkpoint (bool): Whether to use checkpointing to save memory. Default: False.
     """
 
     def __init__(
@@ -702,7 +702,7 @@ def swin_tiny_patch4_window7_224(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -740,7 +740,7 @@ def swin_small_patch4_window7_224(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -778,7 +778,7 @@ def swin_base_patch4_window7_224(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -816,7 +816,7 @@ def swin_base_patch4_window12_384(pretrained=False, progress=True, **kwargs):
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -854,7 +854,7 @@ def swin_base_patch4_window7_224_in22k_to_1k(pretrained=False, progress=True, **
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -894,7 +894,7 @@ def swin_base_patch4_window12_384_in22k_to_1k(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -934,7 +934,7 @@ def swin_large_patch4_window7_224_in22k_to_1k(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -974,7 +974,7 @@ def swin_large_patch4_window12_384_in22k_to_1k(
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 

--- a/flowvision/models/utils.py
+++ b/flowvision/models/utils.py
@@ -74,12 +74,12 @@ def load_state_dict_from_url(
         model_dir (string, optional): directory in which to save the object
         map_location (optional): a function or a dict specifying how to remap storage locations (see flow.load)
         progress (bool, optional): whether or not to display a progress bar to stderr.
-            Default: True
+            Default: ``True``
         check_hash(bool, optional): If True, the filename part of the URL should follow the naming convention
             ``filename-<sha256>.ext`` where ``<sha256>`` is the first eight or more
             digits of the SHA256 hash of the contents of the file. The hash is used to
             ensure unique names and to verify the contents of the file.
-            Default: False
+            Default: ``False``
         file_name (string, optional): name for the downloaded file. Filename from `url` will be used if not set
 
     """
@@ -126,9 +126,9 @@ def download_url_to_file(url, dst, hash_prefix=None, progress=True):
         url (string): URL of the object to download
         dst (string): Full path where object will be saved, e.g. `/tmp/temporary_file`
         hash_prefix (string, optional): If not None, the SHA256 downloaded file should start with `hash_prefix`.
-            Default: None
+            Default: ``None``
         progress (bool, optional): whether or not to display a progress bar to stderr
-            Default: True
+            Default: ``True``
     """
     file_size = None
     # We use a different API for python2 since urllib(2) doesn't recognize the CA

--- a/flowvision/models/utils.py
+++ b/flowvision/models/utils.py
@@ -80,7 +80,7 @@ def load_state_dict_from_url(
             digits of the SHA256 hash of the contents of the file. The hash is used to
             ensure unique names and to verify the contents of the file.
             Default: False
-        file_name (string, optional): name for the downloaded file. Filename from `url` will be used if not set.
+        file_name (string, optional): name for the downloaded file. Filename from `url` will be used if not set
 
     """
 

--- a/flowvision/models/vgg.py
+++ b/flowvision/models/vgg.py
@@ -169,7 +169,7 @@ def vgg11(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> VGG
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -193,7 +193,7 @@ def vgg11_bn(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> 
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -217,7 +217,7 @@ def vgg13(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> VGG
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -241,7 +241,7 @@ def vgg13_bn(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> 
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -265,7 +265,7 @@ def vgg16(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> VGG
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -289,7 +289,7 @@ def vgg16_bn(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> 
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -313,7 +313,7 @@ def vgg19(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> VGG
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -337,7 +337,7 @@ def vgg19_bn(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> 
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 

--- a/flowvision/models/vgg.py
+++ b/flowvision/models/vgg.py
@@ -169,7 +169,7 @@ def vgg11(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> VGG
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -193,7 +193,7 @@ def vgg11_bn(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> 
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -217,7 +217,7 @@ def vgg13(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> VGG
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -241,7 +241,7 @@ def vgg13_bn(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> 
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -265,7 +265,7 @@ def vgg16(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> VGG
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -289,7 +289,7 @@ def vgg16_bn(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> 
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -313,7 +313,7 @@ def vgg19(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> VGG
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -337,7 +337,7 @@ def vgg19_bn(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> 
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 

--- a/flowvision/models/vgg.py
+++ b/flowvision/models/vgg.py
@@ -1,5 +1,5 @@
 """
-Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/vgg.py
+Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/vgg.py.
 """
 from typing import Union, List, Dict, Any, cast
 

--- a/flowvision/models/vgg.py
+++ b/flowvision/models/vgg.py
@@ -169,7 +169,7 @@ def vgg11(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> VGG
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -193,7 +193,7 @@ def vgg11_bn(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> 
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -217,7 +217,7 @@ def vgg13(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> VGG
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -241,7 +241,7 @@ def vgg13_bn(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> 
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -265,7 +265,7 @@ def vgg16(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> VGG
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -289,7 +289,7 @@ def vgg16_bn(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> 
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -313,7 +313,7 @@ def vgg19(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> VGG
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -337,7 +337,7 @@ def vgg19_bn(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> 
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 

--- a/flowvision/models/vgg.py
+++ b/flowvision/models/vgg.py
@@ -1,5 +1,5 @@
 """
-Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/vgg.py.
+Modified from https://github.com/pytorch/vision/blob/main/torchvision/models/vgg.py
 """
 from typing import Union, List, Dict, Any, cast
 

--- a/flowvision/models/vit.py
+++ b/flowvision/models/vit.py
@@ -305,7 +305,7 @@ def vit_b_16_224(pretrained: bool = False, progress: bool = True, **kwargs: Any)
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -344,7 +344,7 @@ def vit_b_16_384(pretrained: bool = False, progress: bool = True, **kwargs: Any)
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -383,7 +383,7 @@ def vit_b_32_224(pretrained: bool = False, progress: bool = True, **kwargs: Any)
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -422,7 +422,7 @@ def vit_b_32_384(pretrained: bool = False, progress: bool = True, **kwargs: Any)
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -461,7 +461,7 @@ def vit_l_16_384(pretrained: bool = False, progress: bool = True, **kwargs: Any)
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -499,7 +499,7 @@ def vit_l_32_384(pretrained: bool = False, progress: bool = True, **kwargs: Any)
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderrt. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 

--- a/flowvision/models/vit.py
+++ b/flowvision/models/vit.py
@@ -305,7 +305,7 @@ def vit_b_16_224(pretrained: bool = False, progress: bool = True, **kwargs: Any)
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -344,7 +344,7 @@ def vit_b_16_384(pretrained: bool = False, progress: bool = True, **kwargs: Any)
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -383,7 +383,7 @@ def vit_b_32_224(pretrained: bool = False, progress: bool = True, **kwargs: Any)
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -422,7 +422,7 @@ def vit_b_32_384(pretrained: bool = False, progress: bool = True, **kwargs: Any)
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -461,7 +461,7 @@ def vit_l_16_384(pretrained: bool = False, progress: bool = True, **kwargs: Any)
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 
@@ -499,7 +499,7 @@ def vit_l_32_384(pretrained: bool = False, progress: bool = True, **kwargs: Any)
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
 
     For example:
 

--- a/flowvision/models/vit.py
+++ b/flowvision/models/vit.py
@@ -305,7 +305,7 @@ def vit_b_16_224(pretrained: bool = False, progress: bool = True, **kwargs: Any)
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -344,7 +344,7 @@ def vit_b_16_384(pretrained: bool = False, progress: bool = True, **kwargs: Any)
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -383,7 +383,7 @@ def vit_b_32_224(pretrained: bool = False, progress: bool = True, **kwargs: Any)
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -422,7 +422,7 @@ def vit_b_32_384(pretrained: bool = False, progress: bool = True, **kwargs: Any)
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -461,7 +461,7 @@ def vit_l_16_384(pretrained: bool = False, progress: bool = True, **kwargs: Any)
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 
@@ -499,7 +499,7 @@ def vit_l_32_384(pretrained: bool = False, progress: bool = True, **kwargs: Any)
 
     Args:
         pretrained (bool): Whether to download the pre-trained model on ImageNet. Default: ``False``
-        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``
+        progress (bool): If True, displays a progress bar of the download to stderr. Default: ``True``.
 
     For example:
 


### PR DESCRIPTION
1. Args参数最后一个结尾加标点符号，其他不加（参考torchvision）。完成分类models（args:全都不加句号）
2. 修改stderrt 为stderr。完成
3. Default: ``False``需要统一（有些是Default: **False**）。完成
4. 首行文件加上句号。完成分类models（撤回）
5. 方法的输入输出都指定类型。暂时不修改
6. 给所有Default后的参数加`` ``。完成分类models
7. args:参数里面首字母大写。完成
8. args:规范。参数：解释。需要修改densenet。完成
9. args：参数错误 res2net。完成
10. 连续两个空格：swin_transformer。完成


Note:_make_divisible很多模型都使用，应该抽出来