### PR TITLE
Update flowvision download func

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -19,6 +19,7 @@
 - Refator `Vision Transformer` model [#115](https://github.com/Oneflow-Inc/vision/pull/115)
 - Refine `flowvision.models.ModelCreator` to support `ModelCreator.model_list` func [#123](https://github.com/Oneflow-Inc/vision/pull/123)
 - Refator README [#124](https://github.com/Oneflow-Inc/vision/pull/124)
+- Refine `load_state_dict_from_url` in `flowvision.models.utils` to support downloading pretrained weights to cache dir `~/.oneflow/flowvision_cache` [#127](https://github.com/Oneflow-Inc/vision/pull/127)
 
 
 **Docs Update**

--- a/flowvision/models/utils.py
+++ b/flowvision/models/utils.py
@@ -18,6 +18,7 @@ import oneflow as flow
 
 HASH_REGEX = re.compile(r"([a-f0-9]*)_")
 
+
 def get_cache_dir(cache_dir: Optional[str] = None) -> str:
     """
     Modified from https://github.com/facebookresearch/iopath/blob/main/iopath/common/file_io.py
@@ -42,6 +43,7 @@ def get_cache_dir(cache_dir: Optional[str] = None) -> str:
         logger.warning(f"{cache_dir} is not accessible! Using {tmp_dir} instead!")
         cache_dir = tmp_dir
     return cache_dir
+
 
 def _is_legacy_tar_format(filename):
     return tarfile.is_tarfile(filename)

--- a/flowvision/models/utils.py
+++ b/flowvision/models/utils.py
@@ -47,7 +47,7 @@ def _is_legacy_tar_format(filename):
     return tarfile.is_tarfile(filename)
 
 
-def _legacy_tar_load(filename, model_dir, map_location):
+def _legacy_tar_load(filename, model_dir, map_location, delete_tar_file=True):
     with tarfile.open(filename) as f:
         members = f.getnames()
         extracted_name = members[0]
@@ -55,6 +55,8 @@ def _legacy_tar_load(filename, model_dir, map_location):
         if not os.path.exists(model_dir):
             os.mkdir(model_dir)
         f.extractall(model_dir)
+    if delete_tar_file:
+        os.remove(filename)
     return flow.load(extracted_file)
 
 
@@ -62,7 +64,7 @@ def _is_legacy_zip_format(filename):
     return zipfile.is_zipfile(filename)
 
 
-def _legacy_zip_load(filename, model_dir, map_location):
+def _legacy_zip_load(filename, model_dir, map_location, delete_zip_file=True):
     # Note: extractall() defaults to overwrite file if exists. No need to clean up beforehand.
     #       We deliberately don't handle tarfile here since our legacy serialization format was in tar.
     with zipfile.ZipFile(filename) as f:
@@ -72,9 +74,9 @@ def _legacy_zip_load(filename, model_dir, map_location):
         if not os.path.exists(extracted_file):
             os.mkdir(extracted_file)
         f.extractall(model_dir)
-    # TODO: flow.load doesn't have map_location
-    # return flow.load(extracted_file, map_location=map_location)
-    return flow.load(extracted_file)
+    if delete_zip_file:
+        os.remove(filename)
+    return flow.load(extracted_file, map_location)
 
 
 def load_state_dict_from_url(
@@ -84,6 +86,7 @@ def load_state_dict_from_url(
     progress=True,
     check_hash=False,
     file_name=None,
+    delete_file=True,
 ):
     r"""Loads the OneFlow serialized object at the given URL.
 
@@ -105,11 +108,8 @@ def load_state_dict_from_url(
             ensure unique names and to verify the contents of the file.
             Default: ``False``
         file_name (string, optional): name for the downloaded file. Filename from `url` will be used if not set
-
+        delete_file (bool, optional): delete downloaded `.zip` file or `.tar.gz` file after unzipping them.
     """
-
-    if map_location is not None:
-        warnings.warn("Map location is not supported yet.")
 
     try:
         model_dir = get_cache_dir(model_dir)
@@ -135,9 +135,9 @@ def load_state_dict_from_url(
         download_url_to_file(url, cached_file, hash_prefix, progress=progress)
 
     if _is_legacy_zip_format(cached_file):
-        return _legacy_zip_load(cached_file, model_dir, map_location)
+        return _legacy_zip_load(cached_file, model_dir, map_location, delete_file)
     elif _is_legacy_tar_format(cached_file):
-        return _legacy_tar_load(cached_file, model_dir, map_location)
+        return _legacy_tar_load(cached_file, model_dir, map_location, delete_file)
     else:
         state_dict = flow.load(cached_file)
         return state_dict

--- a/flowvision/models/utils.py
+++ b/flowvision/models/utils.py
@@ -81,7 +81,7 @@ def _legacy_zip_load(filename, model_dir, map_location, delete_zip_file=True):
 
 def load_state_dict_from_url(
     url,
-    model_dir="./checkpoints",
+    model_dir=None,
     map_location=None,
     progress=True,
     check_hash=False,

--- a/flowvision/models/utils.py
+++ b/flowvision/models/utils.py
@@ -81,7 +81,7 @@ def _legacy_zip_load(filename, model_dir, map_location, delete_zip_file=True):
 
 def load_state_dict_from_url(
     url,
-    model_dir=None,
+    model_dir="./checkpoints",
     map_location=None,
     progress=True,
     check_hash=False,
@@ -125,6 +125,12 @@ def load_state_dict_from_url(
     filename = os.path.basename(parts.path)
     if file_name is not None:
         filename = file_name
+    # if already download the weight, directly return loaded state_dict
+    pretrained_weight_dir = os.path.join(model_dir, filename.split(".")[0])
+    if os.path.exists(pretrained_weight_dir):
+        state_dict = flow.load(pretrained_weight_dir)
+        return state_dict
+
     cached_file = os.path.join(model_dir, filename)
     if not os.path.exists(cached_file):
         sys.stderr.write('Downloading: "{}" to {}\n'.format(url, cached_file))


### PR DESCRIPTION
## TODO
- [x] Support downloading pretrained weight to `~/.oneflow/flowvision_cache`
- [x] Add args to control if delete `.zip` file after unzip the pretrained weight
- [ ] ~~Support for redownloading after some interruption（optional）~~
- [x] Update ChangeLog

## Summary
- 支持下载预训练权重到cache文件夹下
- 支持下载解压预训练权重后自动删除下载好的`.zip`或者`.tar.gz`文件
- 支持打断下载后，可以在断点重新下载（optional），暂时没有想到特别好的办法，留到之后再解决
- 不会重复下载