### PR TITLE
optimize some transforms

### DIFF
--- a/flowvision/data/transforms_factory.py
+++ b/flowvision/data/transforms_factory.py
@@ -122,7 +122,7 @@ def transforms_imagenet_train(
         # prefetcher and collate will handle tensor conversion and norm
         final_tfl += [transforms.ToNumpy()]
     else:
-        final_tfl += [transforms.Normalize(mean=mean, std=std), transforms.ToTensor()]
+        final_tfl += [transforms.ToTensor(), transforms.Normalize(mean=mean, std=std)]
         if re_prob > 0.0:
             final_tfl.append(
                 RandomErasing(

--- a/flowvision/transforms/transforms.py
+++ b/flowvision/transforms/transforms.py
@@ -773,9 +773,7 @@ class RandomResizedCrop(Module):
         log_ratio = np.log(np.array(ratio))
         for _ in range(10):
             target_area = area * np.random.uniform(scale[0], scale[1])
-            aspect_ratio = np.exp(
-                np.random.uniform(log_ratio[0], log_ratio[1])
-            )
+            aspect_ratio = np.exp(np.random.uniform(log_ratio[0], log_ratio[1]))
 
             w = int(round(math.sqrt(target_area * aspect_ratio)))
             h = int(round(math.sqrt(target_area / aspect_ratio)))

--- a/flowvision/transforms/transforms.py
+++ b/flowvision/transforms/transforms.py
@@ -770,19 +770,19 @@ class RandomResizedCrop(Module):
         width, height = F._get_image_size(img)
         area = height * width
 
-        log_ratio = flow.log(flow.tensor(ratio))
+        log_ratio = np.log(np.array(ratio))
         for _ in range(10):
-            target_area = area * flow.empty(1).uniform_(scale[0], scale[1]).item()
-            aspect_ratio = flow.exp(
-                flow.empty(1).uniform_(log_ratio[0], log_ratio[1])
-            ).item()
+            target_area = area * np.random.uniform(scale[0], scale[1])
+            aspect_ratio = np.exp(
+                np.random.uniform(log_ratio[0], log_ratio[1])
+            )
 
             w = int(round(math.sqrt(target_area * aspect_ratio)))
             h = int(round(math.sqrt(target_area / aspect_ratio)))
 
             if 0 < w <= width and 0 < h <= height:
-                i = flow._C.randint(0, height - h + 1, size=(1,)).item()
-                j = flow._C.randint(0, width - w + 1, size=(1,)).item()
+                i = np.random.randint(0, height - h + 1)
+                j = np.random.randint(0, width - w + 1)
                 return i, j, h, w
 
         # Fallback to central crop


### PR DESCRIPTION
优化一些 swin dataloader 涉及的 transform，一部分改动是改为了和 pytorch 一致的性能较优的写法（如 from_numpy），另一部分改动是把一些细碎的 oneflow 操作改成了 numpy 操作，避免 oneflow 的 overhead