### PR TITLE
fix bug of ToTensor when input is uint8

### DIFF
--- a/flowvision/transforms/functional.py
+++ b/flowvision/transforms/functional.py
@@ -156,10 +156,10 @@ def to_tensor(pic):
             pic = pic[:, :, None]
 
         img = flow.tensor(
-            np.ascontiguousarray(pic.transpose((2, 0, 1)), dtype=np.float32)
+            np.ascontiguousarray(pic.transpose((2, 0, 1)))
         )
         # backward compatibility
-        if img.dtype == flow.int:
+        if img.dtype == flow.uint8:
             return flow._C.cast(img, dtype=default_float_dtype).div(255)
         else:
             return img


### PR DESCRIPTION
复现代码：
```python

>>> import numpy as np
>>> import flowvision
>>> import torchvision
>>> img = np.random.randint(0, 256, size=(3, 112, 112), dtype=np.uint8)
>>> flowvision.transforms.ToTensor()(img)
tensor([[[103.,   8., 241.,  ...,  35., 193., 100.],
         [205., 245.,  59.,  ..., 177., 147., 230.],
         [188., 109., 248.,  ..., 117., 205.,   1.]],

        [[223.,  54., 232.,  ...,  41.,  55., 234.],
         [ 20., 107., 196.,  ...,  71.,  27.,  45.],
         [ 62.,  85., 161.,  ..., 161., 133., 206.]],

        [[231., 158., 223.,  ..., 149.,  58.,  70.],
         [124., 178., 178.,  ..., 121., 232., 104.],
         [232., 153.,  91.,  ..., 208., 222.,  50.]],

        ...,

        [[221., 155., 193.,  ...,  96., 113., 144.],
         [180., 232.,  91.,  ..., 139.,  89., 175.],
         [ 45., 135.,  42.,  ...,  22.,  81.,  60.]],

        [[175.,  89.,  79.,  ...,  56., 183., 123.],
         [ 88.,  43., 122.,  ..., 253., 246., 121.],
         [246.,  99., 213.,  ..., 176.,   8., 118.]],

        [[121.,  60., 110.,  ..., 120., 244., 180.],
         [199.,  84.,  72.,  ..., 195., 168.,  79.],
         [137.,  51.,  22.,  ..., 155., 249.,  11.]]], dtype=oneflow.float32)
>>> torchvision.transforms.ToTensor()(img)
tensor([[[0.4039, 0.0314, 0.9451,  ..., 0.1373, 0.7569, 0.3922],
         [0.8039, 0.9608, 0.2314,  ..., 0.6941, 0.5765, 0.9020],
         [0.7373, 0.4275, 0.9725,  ..., 0.4588, 0.8039, 0.0039]],

        [[0.8745, 0.2118, 0.9098,  ..., 0.1608, 0.2157, 0.9176],
         [0.0784, 0.4196, 0.7686,  ..., 0.2784, 0.1059, 0.1765],
         [0.2431, 0.3333, 0.6314,  ..., 0.6314, 0.5216, 0.8078]],

        [[0.9059, 0.6196, 0.8745,  ..., 0.5843, 0.2275, 0.2745],
         [0.4863, 0.6980, 0.6980,  ..., 0.4745, 0.9098, 0.4078],
         [0.9098, 0.6000, 0.3569,  ..., 0.8157, 0.8706, 0.1961]],

        ...,

        [[0.8667, 0.6078, 0.7569,  ..., 0.3765, 0.4431, 0.5647],
         [0.7059, 0.9098, 0.3569,  ..., 0.5451, 0.3490, 0.6863],
         [0.1765, 0.5294, 0.1647,  ..., 0.0863, 0.3176, 0.2353]],

        [[0.6863, 0.3490, 0.3098,  ..., 0.2196, 0.7176, 0.4824],
         [0.3451, 0.1686, 0.4784,  ..., 0.9922, 0.9647, 0.4745],
         [0.9647, 0.3882, 0.8353,  ..., 0.6902, 0.0314, 0.4627]],

        [[0.4745, 0.2353, 0.4314,  ..., 0.4706, 0.9569, 0.7059],
         [0.7804, 0.3294, 0.2824,  ..., 0.7647, 0.6588, 0.3098],
         [0.5373, 0.2000, 0.0863,  ..., 0.6078, 0.9765, 0.0431]]])
```

flowvision对应的代码在 
https://github.com/Oneflow-Inc/vision/blob/f656cf64ca809e9bd617549662087eb0ee0db6af/flowvision/transforms/functional.py#L153-L165

torchvision对应的代码在 
https://github.com/pytorch/vision/blob/35d1d9d3f01016c65ac7f3d0700d2474929acdea/torchvision/transforms/functional.py#L145-L155

flowvision在第159行代码中返回的Tensor的dtype恒为float32，造成下面的条件判断恒为False，导致结果错误，此PR修复了这一问题。