### PR TITLE
ResNet-50 训练

### DIFF
--- a/docs/source/flowvision.layers.rst
+++ b/docs/source/flowvision.layers.rst
@@ -10,5 +10,6 @@ Plug and Play Modules or Functions that are specific for Computer Vision Tasks
         batched_nms,
         box_iou,
         FeaturePyramidNetwork,
-        MultiScaleRoIAlign
+        MultiScaleRoIAlign,
+        SEModule
   

--- a/flowvision/layers/attention/se.py
+++ b/flowvision/layers/attention/se.py
@@ -11,8 +11,8 @@ class SEModule(nn.Module):
         channels (int): The input channel size
         reduction (int): Ratio that allows us to vary the capacity and computational cost of the SE Module. Default: 16
         rd_channels (int or None): Number of reduced channels. If none, uses reduction to calculate
-        act_layer (flow.nn.Module): An activation layer used between two FC layers. Default: flow.nn.ReLU
-        gate_layer (flow.nn.Module): An activation layer used after two FC layers. Default: flow.nn.Sigmoid
+        act_layer (flow.nn.Module): An activation layer used after the first FC layer. Default: flow.nn.ReLU
+        gate_layer (flow.nn.Module): An activation layer used after the second FC layer. Default: flow.nn.Sigmoid
         mlp_bias (bool): If True, add learnable bias to the linear layers. Default: False
     """
 

--- a/flowvision/layers/attention/se.py
+++ b/flowvision/layers/attention/se.py
@@ -9,7 +9,7 @@ class SEModule(nn.Module):
 
     Args:
         channels (int): The input channel size
-        reduction (int): Ratio that allows us tovary the capacity and computational cost of the SE model. Default: 16
+        reduction (int): Ratio that allows us to vary the capacity and computational cost of the SE SEModule. Default: 16
         rd_channels (int or None): Number of reduced channels. If none, uses reduction to calculate
         act_layer (flow.nn.Module): An activation layer used between two FC layers. Default: flow.nn.ReLU
         gate_layer (flow.nn.Module): An activation layer used after two FC layers. Default: flow.nn.Sigmoid

--- a/flowvision/layers/attention/se.py
+++ b/flowvision/layers/attention/se.py
@@ -3,6 +3,19 @@ import oneflow.nn as nn
 
 
 class SEModule(nn.Module):
+    """
+    "Squeeze-and-Excitation" block adaptively recalibrates channel-wise feature responses. This is based on
+    `"Squeeze-and-Excitation Networks" <https://arxiv.org/abs/1709.01507>`_. This unit is designed to improve the representational capacity of a network by enabling it to perform dynamic channel-wise feature recalibration.
+
+    Args:
+        channels (int): The input channel size
+        reduction (int): Ratio that allows us tovary the capacity and computational cost of the SE model. Default: 16
+        rd_channels (int or None): Number of reduced channels. If none, uses reduction to calculate
+        act_layer (flow.nn.Module): An activation layer used between two FC layers. Default: flow.nn.ReLU
+        gate_layer (flow.nn.Module): An activation layer used after two FC layers. Default: flow.nn.Sigmoid
+        mlp_bias (bool): If True, add learnable bias to the linear layers. Default: False
+    """
+
     def __init__(
         self,
         channels,

--- a/flowvision/layers/attention/se.py
+++ b/flowvision/layers/attention/se.py
@@ -9,7 +9,7 @@ class SEModule(nn.Module):
 
     Args:
         channels (int): The input channel size
-        reduction (int): Ratio that allows us to vary the capacity and computational cost of the SE SEModule. Default: 16
+        reduction (int): Ratio that allows us to vary the capacity and computational cost of the SE Module. Default: 16
         rd_channels (int or None): Number of reduced channels. If none, uses reduction to calculate
         act_layer (flow.nn.Module): An activation layer used between two FC layers. Default: flow.nn.ReLU
         gate_layer (flow.nn.Module): An activation layer used after two FC layers. Default: flow.nn.Sigmoid

--- a/flowvision/layers/attention/se.py
+++ b/flowvision/layers/attention/se.py
@@ -1,6 +1,8 @@
+from typing import Optional
+
 import oneflow as flow
 import oneflow.nn as nn
-
+from oneflow.nn import ReLU, Sigmoid
 
 class SEModule(nn.Module):
     """
@@ -11,19 +13,19 @@ class SEModule(nn.Module):
         channels (int): The input channel size
         reduction (int): Ratio that allows us to vary the capacity and computational cost of the SE Module. Default: 16
         rd_channels (int or None): Number of reduced channels. If none, uses reduction to calculate
-        act_layer (flow.nn.Module): An activation layer used after the first FC layer. Default: flow.nn.ReLU
-        gate_layer (flow.nn.Module): An activation layer used after the second FC layer. Default: flow.nn.Sigmoid
-        mlp_bias (bool): If True, add learnable bias to the linear layers. Default: False
+        act_layer (Optional[ReLU]): An activation layer used after the first FC layer. Default: flow.nn.ReLU
+        gate_layer (Optional[Sigmoid]): An activation layer used after the second FC layer. Default: flow.nn.Sigmoid
+        mlp_bias (bool): If True, add learnable bias to the linear layers. Default: True
     """
 
     def __init__(
         self,
-        channels,
-        reduction=16,
-        rd_channels=None,
-        act_layer=nn.ReLU,
-        gate_layer=nn.Sigmoid,
-        mlp_bias=False,
+        channels: int,
+        reduction: int = 16,
+        rd_channels: int = None,
+        act_layer: Optional[ReLU] = nn.ReLU,
+        gate_layer: Optional[Sigmoid] = nn.Sigmoid,
+        mlp_bias=True,
     ):
         super(SEModule, self).__init__()
         rd_channels = channels // reduction if rd_channels is None else rd_channels


### PR DESCRIPTION
## ResNet-50 训练
参照当前 vision 下的 project 复现 resnet-50 训练和精度对齐。

## 参考
- pytorch：[resent](https://github.com/pytorch/vision/blob/main/torchvision/models/resnet.py)
- timm：[resnet](https://github.com/rwightman/pytorch-image-models/blob/master/timm/models/resnet.py)


### 主要目标

- [ ] 2022.05.11 - 2022.5.12：熟悉 vision 下的分类模型训练代码，数据集配置并跑通。
- [ ] 2022.05.12 - 2022.05.20：对照 timm 和 pytorch 复现 reset-50 训练代码，对齐相关训练条件，测试并使用多卡训练。
- [ ] 2022.05.21 - 2022.05.27：对比精度差异调整并复现精度，最终将训练好的权重替换为 oneflow 版本。

项目负责人：林松
预计完成时间：2022.05.27


## 相关 PR

> 罗列对应的 PR，以为一个 issue 可能会对应多个 PR，所以这里提供的是表格

| PR                                                           | 作者 | reviewer | 日期     |      |
| ------------------------------------------------------------ | ---- | -------- | -------- | ---- |
| [首次上传提交代码](https://github.com/Oneflow-Inc/vision/pull/221) | 林松 | zzzzzzz  | 20220510 |      |
