### PR TITLE
refine RandomAffine RandomRotation

### DIFF
--- a/flowvision/transforms/__init__.py
+++ b/flowvision/transforms/__init__.py
@@ -58,6 +58,7 @@ __all__ = [
     "RandomSizedCrop",
     "RandomAffine",
     "RandomGrayscale",
+    "RandomRotation",
     "Grayscale",
     "FiveCrop",
     "TenCrop",

--- a/flowvision/transforms/__init__.py
+++ b/flowvision/transforms/__init__.py
@@ -23,6 +23,7 @@ from .transforms import (
     RandomSizedCrop,
     RandomAffine,
     RandomGrayscale,
+    RandomRotation,
     Grayscale,
     FiveCrop,
     TenCrop,

--- a/flowvision/transforms/functional_pil.py
+++ b/flowvision/transforms/functional_pil.py
@@ -32,6 +32,17 @@ def _get_image_num_channels(img: Any) -> int:
         return 1 if img.mode == "L" else 3
 
 
+def get_dimensions(img: Any) -> List[int]:
+    if _is_pil_image(img):
+        if hasattr(img, "getbands"):
+            channels = len(img.getbands())
+        else:
+            channels = img.channels
+        width, height = img.size
+        return [channels, height, width]
+    raise TypeError(f"Unexpected type {type(img)}")
+
+
 def hflip(img):
     if not _is_pil_image(img):
         raise TypeError("img should be PIL Image. Got {}".format(type(img)))

--- a/flowvision/transforms/functional_tensor.py
+++ b/flowvision/transforms/functional_tensor.py
@@ -604,7 +604,10 @@ def _gen_affine_grid(
     base_grid = flow.empty(1, oh, ow, 3, dtype=theta.dtype, device=theta.device)
     x_grid = flow.linspace(-ow * 0.5 + d, ow * 0.5 + d - 1, steps=ow, device=theta.device)
     base_grid[..., 0].copy_(x_grid)
-    y_grid = flow.linspace(-oh * 0.5 + d, oh * 0.5 + d - 1, steps=oh, device=theta.device).unsqueeze_(-1)
+    # y_grid = flow.linspace(-oh * 0.5 + d, oh * 0.5 + d - 1, steps=oh, device=theta.device).unsqueeze_(-1)
+    # TODO:(oneflow) support api tensor.unsqueeze_
+    y_grid = flow.linspace(-oh * 0.5 + d, oh * 0.5 + d - 1, steps=oh, device=theta.device)
+    y_grid = flow.unsqueeze(y_grid,-1)
     base_grid[..., 1].copy_(y_grid)
     base_grid[..., 2].fill_(1)
 

--- a/flowvision/transforms/transforms.py
+++ b/flowvision/transforms/transforms.py
@@ -1445,7 +1445,7 @@ class RandomGrayscale(Module):
         Returns:
             PIL Image or Tensor: Randomly grayscaled image.
         """
-        num_output_channels = F._get_image_num_channels(img)
+        num_output_channels, _, _ = F.get_dimensions(img)
         if flow.rand(1) < self.p:
             return F.rgb_to_grayscale(img, num_output_channels=num_output_channels)
         return img


### PR DESCRIPTION
- [x] 新增affine方法，fix pr：https://github.com/Oneflow-Inc/vision/pull/259/ 中RandomAffine缺失的`F.affine`方法的bug
- [x] 新增rotate方法，导出`transforms.RandomRotation` api

基于disco diffusion测试通过：https://github.com/Oneflow-Inc/disco-diffusion/commit/2723349f02474a191f7773214ff8b7cf18681f08