### PR TITLE
resnest fix

### DIFF
--- a/flowvision/models/resnest.py
+++ b/flowvision/models/resnest.py
@@ -355,7 +355,7 @@ class ResNest(nn.Module):
                 m.weight.data.normal_(0, math.sqrt(2.0 / n))
             elif isinstance(m, norm_layer):
                 m.weight.data.fill_(1)
-                m.bias.data.zeros_()
+                m.bias.data.zero_()
 
     def _make_layer(
         self,


### PR DESCRIPTION
norm层初始化参数时接口zeros_()报错，根据文档中Tensor.zero_() →Fills self tensor with zeros.改为zero_()进行初始化。