### PR TITLE
Shufflenet v2 pretrained

### DIFF
--- a/flowvision/models/shufflenet_v2.py
+++ b/flowvision/models/shufflenet_v2.py
@@ -22,8 +22,8 @@ __all__ = [
 model_urls = {
     "shufflenet_v2_x0_5": "https://oneflow-public.oss-cn-beijing.aliyuncs.com/model_zoo/flowvision/classification/ShuffleNetV2/shufflenet_v2_x0_5.zip",
     "shufflenet_v2_x1_0": "https://oneflow-public.oss-cn-beijing.aliyuncs.com/model_zoo/flowvision/classification/ShuffleNetV2/shufflenet_v2_x1_0.zip",
-    "shufflenet_v2_x1_5": None,
-    "shufflenet_v2_x2_0": None,
+    "shufflenet_v2_x1_5": "https://oneflow-public.oss-cn-beijing.aliyuncs.com/model_zoo/flowvision/classification/ShuffleNetV2/shufflenet_v2_x1_5.zip",
+    "shufflenet_v2_x2_0": "https://oneflow-public.oss-cn-beijing.aliyuncs.com/model_zoo/flowvision/classification/ShuffleNetV2/shufflenet_v2_x2_0.zip",
 }
 
 

--- a/flowvision/models/utils.py
+++ b/flowvision/models/utils.py
@@ -73,8 +73,6 @@ def _legacy_zip_load(filename, model_dir, map_location, delete_zip_file=True):
         members = f.infolist()
         extracted_name = members[0].filename
         extracted_file = os.path.join(model_dir, extracted_name)
-        if not os.path.exists(extracted_file):
-            os.mkdir(extracted_file)
         f.extractall(model_dir)
     if delete_zip_file and os.path.exists(filename):
         os.remove(filename)


### PR DESCRIPTION
Added two pre-trained models. These two models are from torchvision, with original files ending in pth. The file names have been modified according to the conventions of flowvision, and they have been compressed into a zip file and uploaded to OSS.

| filename           | from torchvision                                             |
| ------------------ | ------------------------------------------------------------ |
| shufflenet_v2_x2_0 | https://download.pytorch.org/models/shufflenetv2_x2_0-8be3c8ee.pth |
| shufflenet_v2_x1_5 | https://download.pytorch.org/models/shufflenetv2_x1_5-3c479a10.pth |

In `flowvision/models/utils.py`, these two lines will create an empty directory, which will cause the failure of decompression. Therefore, I have removed these two lines.

```python
        if not os.path.exists(extracted_file):
            os.mkdir(extracted_file)
```

